### PR TITLE
ci: switch dependabot to daily vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
+# Daily vulnerability and dependency scanning
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     labels: ["dependencies", "ci"]


### PR DESCRIPTION
Change schedule from weekly to daily for AI Risk Checklist compliance.