### PR TITLE
docs: align formal narrative with proof_coverage source-of-truth

### DIFF
--- a/PROOF_COVERAGE.md
+++ b/PROOF_COVERAGE.md
@@ -3,27 +3,35 @@
 Источник: `spec/SECTION_HASHES.json`  
 Машинный реестр: `rubin-formal/proof_coverage.json`
 
-Текущее состояние: pinned секции заведены со статусом `stated` в рамках `proof_level=byte-model`,
-а conformance-фикстуры `conformance/fixtures/CV-*.json` полностью покрыты Lean replay-слоем.
+Текущее состояние: machine-readable source-of-truth (`proof_coverage.json`) фиксирует
+`proof_level=refinement`, `claim_level=refined`, и явную формальную матрицу по 13 pinned section keys.
+Conformance-фикстуры `conformance/fixtures/CV-*.json` покрыты Lean replay/refinement слоем.
 
 ## Термины (важно)
 
-- `proof_level=byte-model` означает: в репо есть исполняемый (native_decide) Lean replay-слой,
-  который проверяет byte-level свойства на наборе conformance-векторов (CV-*.json).
+- `proof_level=refinement` означает: в репо есть исполняемый Lean replay-слой и trace-based
+  Go(reference) → Lean refinement checks для критических ops на conformance-наборе.
 - `claim_level` фиксирует допустимый публичный уровень заявлений:
   - `toy` (только model-baseline),
   - `byte` (byte-accurate слой),
   - `refined` (refinement to executable path).
 - `status=proved/stated/deferred` относится к конкретной pinned-секции **в рамках указанного `proof_level`**.
 
-Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать `proof_level=byte-model`
-как “formal verification of CANONICAL”.
+Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать текущий `proof_level=refinement`
+как “formal verification of CANONICAL for all inputs/sections”.
+
+Связка с hash-pinning:
+
+- `spec/SECTION_HASHES.json` сейчас содержит 17 pinned section keys.
+- `proof_coverage.json` явно покрывает 13 из них как formal registry entries.
+- Остальные pinned keys считаются закрытыми только через conformance/CI evidence, если не добавлены
+  отдельные formal entries.
 
 ## Путь к freeze-ready
 
-1. Углубить доказательства до байтовой эквивалентности формул из CANONICAL.
-2. Для consensus-critical safety-инвариантов добавить refinement-слой (model → executable path).
-3. Держать матрицу покрытия в синхроне с hash-pinning CANONICAL.
+1. Расширить formal registry до полного множества pinned section keys.
+2. Углубить доказательства beyond-fixtures для consensus-critical safety-инвариантов.
+3. Держать матрицу покрытия в синхроне с hash-pinning CANONICAL и narrative в spec docs.
 
 ## Risk scoring / gates
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,26 @@
 ## Что есть сейчас
 
 - Lean4-пакет `RubinFormal`
-- `proof_coverage.json` с baseline-покрытием всех pinned секций из `spec/SECTION_HASHES.json`
+- `proof_coverage.json` с machine-readable coverage registry (текущая явная формальная матрица: 13 pinned section keys)
 - модельные теоремы (`status=proved`) для pinned секций в `RubinFormal/PinnedSections.lean`
 
 ## Граница claims (критично)
 
-Этот proof-pack — **byte-level replay coverage** для conformance-фикстур (CV-*.json) и baseline-слой
-для дальнейшей формализации. Он нужен для воспроизводимого “якоря”, но **не** является freeze-ready
-универсальной формальной верификацией CANONICAL.
-Текущий machine-readable статус: `proof_level=byte-model`, `claim_level=byte`.
+Этот proof-pack — executable replay/refinement coverage для conformance-фикстур (CV-*.json) и baseline-слой
+для дальнейшей формализации. Он нужен для воспроизводимого “якоря”, но **не** является универсальной
+формальной верификацией CANONICAL.
+Текущий machine-readable статус: `proof_level=refinement`, `claim_level=refined`.
 
 Разрешённые формулировки (OK):
-- “byte-level executable replay coverage for all conformance fixtures (CV-*.json) via Lean native_decide”
-- “refinement to Go/Rust executable path equivalence is pending”
+
+- “Lean executable semantics replay all conformance fixtures (CV-*.json)”
+- “Go(reference) → Lean refinement is checked for critical ops over conformance fixture set”
 
 Запрещённые формулировки (NOT OK):
+
 - “formal verification of RUBIN consensus / CANONICAL”
 - “bit-exact wire/serialization proven”
-- “proved equivalence between spec and Go/Rust implementations”
+- “universal mechanized equivalence between spec text and Go/Rust implementations”
 
 Источник истины по границе claims — `rubin-formal/proof_coverage.json` (`proof_level`, `claims`).
 Дополнительно используется `claim_level` (`toy|byte|refined`) с CI-валидацией консистентности относительно `proof_level`.
@@ -38,9 +40,10 @@
 
 ## Что это значит
 
-- Это **не** полный freeze-ready пакет уровня “универсальная байтовая модель wire + state transition + refinement”.
+- Это **не** полный freeze-ready пакет уровня “универсальная байтовая модель wire + state transition для всех секций”.
 - Консенсусные правила не меняются.
-- Цель текущего шага — зафиксировать воспроизводимый in-repo baseline с byte-level replay покрытием фикстур.
+- Формальный coverage registry сейчас явно отражает 13 pinned section keys; остальные pinned keys
+  покрываются conformance/CI и должны коммуницироваться как такой coverage (без overclaim).
 
 ## Локальный запуск
 
@@ -51,6 +54,6 @@ scripts/dev-env.sh -- bash -lc 'cd rubin-formal && lake build'
 
 ## Дальше
 
-1. Углубить модель до байтовой/сериализационной эквивалентности с CANONICAL.
-2. Разделить модельные и implementation-refinement доказательства.
-3. Поддерживать `proof_coverage.json` в синхроне со `spec/SECTION_HASHES.json`.
+1. Расширить формальный coverage registry с 13 до полного набора pinned section keys.
+2. Углубить универсальные теоремы beyond-fixtures поверх текущего refinement слоя.
+3. Поддерживать `proof_coverage.json` в синхроне со `spec/SECTION_HASHES.json` и narrative в `rubin-spec`.


### PR DESCRIPTION
## Summary
- update formal docs to reflect current machine-readable status (`proof_level=refinement`, `claim_level=refined`)
- align claims language with `proof_coverage.json` allowed/forbidden boundaries
- explicitly document current coverage scope vs pinned section keys

## Validation
- `~/.elan/bin/lake build`

Related: 2tbmz9y2xt-lang/rubin-spec#53
