### PR TITLE
ci: pin third-party GitHub Actions by full SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: leanprover/lean-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: leanprover/lean-action@c544e89643240c6b398f14a431bcdc6309e36b3e # v1
         with:
           build: true
       - name: publish legacy status context "build"
         if: ${{ always() }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           JOB_STATUS: ${{ job.status }}
         with:


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to full commit SHAs in `.github/workflows/ci.yml`
- keep human-readable version tags as inline comments

## Pins
- `actions/checkout` -> `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6`)
- `leanprover/lean-action` -> `c544e89643240c6b398f14a431bcdc6309e36b3e` (`v1`)
- `actions/github-script` -> `ed597411d8f924073f98dfc5c65a23a2325f34cd` (`v8`)

## Validation
- local pin-presence check script PASS
- CI checks on this PR

Closes #9
