### PR TITLE
formal: align with post-audit consensus fixes (Q-AUDIT-POST)

### DIFF
--- a/RubinFormal/ArithmeticSafety.lean
+++ b/RubinFormal/ArithmeticSafety.lean
@@ -1,7 +1,9 @@
 import Std
+import RubinFormal.SubsidyV1
 
 namespace RubinFormal
 
+def maxU64 : Nat := (2 ^ 64) - 1
 def maxU128 : Nat := (2 ^ 128) - 1
 
 def inU128 (x : Nat) : Prop := x ≤ maxU128
@@ -49,5 +51,60 @@ theorem floorDiv_mul_le (a b : Nat) (hb : 0 < b) :
   exact Nat.div_mul_le_self a b
 
 theorem floorDiv_deterministic (a b : Nat) : floorDiv a b = floorDiv a b := rfl
+
+-- §19.1 — Subsidy arithmetic fits in machine integer types.
+-- PR #420 changed consensus implementations to u128/big.Int.
+-- These theorems formally verify the type change is sufficient.
+
+/-- Right-shift never increases a natural number:
+    Nat.shiftRight n k = n / 2^k ≤ n. -/
+private theorem nat_shiftRight_le (n k : Nat) : Nat.shiftRight n k ≤ n := by
+  show n >>> k ≤ n
+  rw [Nat.shiftRight_eq_div_pow]
+  exact Nat.div_le_self n (2 ^ k)
+
+/-- blockSubsidy always returns ≤ MINEABLE_CAP, hence fits in u64. -/
+theorem blockSubsidy_bounded (h ag : Nat) :
+    SubsidyV1.blockSubsidy h ag ≤ SubsidyV1.MINEABLE_CAP := by
+  unfold SubsidyV1.blockSubsidy
+  split
+  · -- h == 0 → result is 0
+    exact Nat.zero_le _
+  · split
+    · -- alreadyGenerated ≥ MINEABLE_CAP → result is TAIL_EMISSION_PER_BLOCK
+      unfold SubsidyV1.TAIL_EMISSION_PER_BLOCK SubsidyV1.MINEABLE_CAP; omega
+    · -- else: let remaining; let baseReward; if ... then TAIL else baseReward
+      -- Beta-reduce let bindings so split can reach the inner if:
+      show (if Nat.shiftRight (SubsidyV1.MINEABLE_CAP - ag) SubsidyV1.EMISSION_SPEED_FACTOR
+              < SubsidyV1.TAIL_EMISSION_PER_BLOCK
+            then SubsidyV1.TAIL_EMISSION_PER_BLOCK
+            else Nat.shiftRight (SubsidyV1.MINEABLE_CAP - ag) SubsidyV1.EMISSION_SPEED_FACTOR)
+            ≤ SubsidyV1.MINEABLE_CAP
+      split
+      · -- baseReward < TAIL → result is TAIL ≤ MINEABLE_CAP
+        unfold SubsidyV1.TAIL_EMISSION_PER_BLOCK SubsidyV1.MINEABLE_CAP; omega
+      · -- baseReward ≥ TAIL → result is shiftRight(remaining, 20) ≤ remaining ≤ MINEABLE_CAP
+        exact Nat.le_trans (nat_shiftRight_le _ _) (Nat.sub_le _ _)
+
+/-- MINEABLE_CAP fits in u64. -/
+theorem mineable_cap_in_u64 : SubsidyV1.MINEABLE_CAP ≤ maxU64 := by
+  native_decide
+
+/-- blockSubsidy result fits in u64. -/
+theorem blockSubsidy_in_u64 (h ag : Nat) :
+    SubsidyV1.blockSubsidy h ag ≤ maxU64 :=
+  Nat.le_trans (blockSubsidy_bounded h ag) mineable_cap_in_u64
+
+/-- alreadyGenerated + blockSubsidy + fees fits in u128 when inputs are bounded.
+    This is the key safety theorem for PR #420 (u128 arithmetic). -/
+theorem subsidy_accumulation_in_u128 (h ag fees : Nat)
+    (hAg : ag ≤ SubsidyV1.MINEABLE_CAP)
+    (hFees : fees ≤ maxU64) :
+    ag + SubsidyV1.blockSubsidy h ag + fees ≤ maxU128 := by
+  have hSub := blockSubsidy_bounded h ag
+  calc ag + SubsidyV1.blockSubsidy h ag + fees
+      ≤ SubsidyV1.MINEABLE_CAP + SubsidyV1.MINEABLE_CAP + maxU64 :=
+        Nat.add_le_add (Nat.add_le_add hAg hSub) hFees
+    _ ≤ maxU128 := by native_decide
 
 end RubinFormal

--- a/RubinFormal/BlockBasicCheckV1.lean
+++ b/RubinFormal/BlockBasicCheckV1.lean
@@ -84,7 +84,14 @@ def validateBlockBasicCheck
   -- signature suite activation gate (no-op after SLH-DSA removal).
   enforceSigSuiteActivation pb.txs blockHeight
 
-  -- validate the same basic invariants as BlockBasicV1.validateBlockBasic, but keep pb for extra checks.
+  -- §25 step order (post-PR#418): pow → target → linkage → merkle → witness_commitment → timestamp
+  BlockBasicV1.powCheck pb.header
+
+  match expectedTarget with
+  | none => pure ()
+  | some exp =>
+      if pb.header.target != exp then throw "BLOCK_ERR_TARGET_INVALID"
+
   match expectedPrevHash with
   | none => pure ()
   | some exp =>
@@ -92,13 +99,6 @@ def validateBlockBasicCheck
 
   let mr ← BlockBasicV1.merkleRootTxids pb.txids
   if mr != pb.header.merkleRoot then throw "BLOCK_ERR_MERKLE_INVALID"
-
-  BlockBasicV1.powCheck pb.header
-
-  match expectedTarget with
-  | none => pure ()
-  | some exp =>
-      if pb.header.target != exp then throw "BLOCK_ERR_TARGET_INVALID"
 
   let wmr ← BlockBasicV1.witnessMerkleRootWtxids pb.wtxids
   let expectCommit := BlockBasicV1.witnessCommitmentHash wmr

--- a/RubinFormal/BlockBasicV1.lean
+++ b/RubinFormal/BlockBasicV1.lean
@@ -266,6 +266,14 @@ def validateBlockBasic
     (expectedPrevHash : Option Bytes)
     (expectedTarget : Option Bytes) : Except String Unit := do
   let pb ← parseBlock blockHex
+  -- §25 step order (post-PR#418): pow → target → linkage → merkle → witness_commitment
+  -- pow check (range + strict-less)
+  powCheck pb.header
+  -- target check
+  match expectedTarget with
+  | none => pure ()
+  | some exp =>
+      if pb.header.target != exp then throw "BLOCK_ERR_TARGET_INVALID"
   -- linkage
   match expectedPrevHash with
   | none => pure ()
@@ -275,13 +283,6 @@ def validateBlockBasic
   let mr ← merkleRootTxids pb.txids
   if mr != pb.header.merkleRoot then
     throw "BLOCK_ERR_MERKLE_INVALID"
-  -- pow check (range + strict-less)
-  powCheck pb.header
-  -- target check
-  match expectedTarget with
-  | none => pure ()
-  | some exp =>
-      if pb.header.target != exp then throw "BLOCK_ERR_TARGET_INVALID"
   -- witness commitment check
   let wmr ← witnessMerkleRootWtxids pb.wtxids
   let expectCommit := witnessCommitmentHash wmr

--- a/RubinFormal/PinnedSections.lean
+++ b/RubinFormal/PinnedSections.lean
@@ -43,6 +43,12 @@ def coreExtCursorNoAmbiguityStatement : Prop :=
         coreExtAssignedWitnessIndex i = coreExtAssignedWitnessIndex j →
           i = j) ∧
       (∀ i : Nat, i < inputCount → coreExtAssignedWitnessIndex i < witnessCount)
+-- §19.1: subsidy arithmetic fits in machine integer types (PR #420).
+def subsidyU128SafetyStatement : Prop :=
+  (∀ h ag : Nat, SubsidyV1.blockSubsidy h ag ≤ SubsidyV1.MINEABLE_CAP) ∧
+  (∀ h ag : Nat, SubsidyV1.blockSubsidy h ag ≤ maxU64) ∧
+  (∀ h ag fees : Nat, ag ≤ SubsidyV1.MINEABLE_CAP → fees ≤ maxU64 →
+    ag + SubsidyV1.blockSubsidy h ag + fees ≤ maxU128)
 
 theorem transaction_wire_proved : transactionWireStatement := by
   refine ⟨?_, ?_, ?_⟩
@@ -110,5 +116,12 @@ theorem core_ext_tightening_proved : coreExtTighteningStatement := by
 theorem core_ext_cursor_no_ambiguity_proved : coreExtCursorNoAmbiguityStatement := by
   intro inputCount witnessCount h
   exact core_ext_no_cursor_ambiguity inputCount witnessCount h
+
+theorem subsidy_u128_safety_proved : subsidyU128SafetyStatement := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact blockSubsidy_bounded
+  · exact blockSubsidy_in_u64
+  · intro h ag fees hAg hFees
+    exact subsidy_accumulation_in_u128 h ag fees hAg hFees
 
 end RubinFormal

--- a/RubinFormal/SubsidyV1.lean
+++ b/RubinFormal/SubsidyV1.lean
@@ -11,6 +11,11 @@ open RubinFormal.BlockBasicV1
 open RubinFormal.UtxoBasicV1
 
 -- Consensus constants (mirror clients/go/consensus/constants.go).
+-- NOTE (§19.1, PR #420): Go uses *big.Int, Rust uses u128 for subsidy
+-- accumulation arithmetic. Lean Nat is unbounded and strictly subsumes
+-- both u64 and u128. The formal bound proof that subsidy values fit in
+-- machine types is in ArithmeticSafety.lean (blockSubsidy_bounded,
+-- subsidy_accumulation_in_u128).
 def MINEABLE_CAP : Nat := 4900000000000000
 def EMISSION_SPEED_FACTOR : Nat := 20
 def TAIL_EMISSION_PER_BLOCK : Nat := 19025875


### PR DESCRIPTION
## Summary
- **ArithmeticSafety**: add u128 subsidy bound theorems (`blockSubsidy_bounded`, `subsidy_accumulation_in_u128`) proving PR #420 type change is sufficient
- **BlockBasicV1/BlockBasicCheckV1**: reorder validation to match §25 post-PR#418 (pow → target → linkage → merkle → witness_commitment → timestamp)
- **PinnedSections**: add 16th proven theorem `subsidyU128SafetyStatement`
- **SubsidyV1**: document `Nat` vs `u128`/`big.Int` equivalence

## Context

After merging 4 architect audit fix PRs on 2026-03-05 (Q-AUDIT-POST-01..04):
- PR #417: SENTINEL keyless enforcement (§14.1/§14.2)
- PR #418: Block validation order correction (§25)
- PR #419: VAULT validation order fix (§24.1)
- PR #420: Subsidy u128/big.Int arithmetic (§19.1)

This PR aligns the Lean 4 formal verification with the updated consensus code.

## Test plan
- [x] `lake build` — 297/297 modules, 0 errors
- [x] `grep -r "sorry" RubinFormal/` — 0 results
- [x] All conformance replay gates pass
- [x] New subsidy u128 theorems type-check via `native_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)