### PR TITLE
formal: close Q-FORMAL-GAP-03 theorem gaps

### DIFF
--- a/RubinFormal/Conformance/CVValidationOrderReplay.lean
+++ b/RubinFormal/Conformance/CVValidationOrderReplay.lean
@@ -2,17 +2,18 @@ import RubinFormal.Conformance.CVValidationOrderVectors
 
 namespace RubinFormal.Conformance
 
+def evalOrderFrom (rest : List ValidationCheck) (evaluated : List String) : (Option String) × (List String) :=
+  match rest with
+  | [] => (none, evaluated)
+  | c :: cs =>
+    let evaluated' := evaluated ++ [c.name]
+    if c.fails then
+      (some c.err, evaluated')
+    else
+      evalOrderFrom cs evaluated'
+
 def evalOrder (checks : List ValidationCheck) : (Option String) × (List String) :=
-  let rec go (rest : List ValidationCheck) (evaluated : List String) : (Option String) × (List String) :=
-    match rest with
-    | [] => (none, evaluated)
-    | c :: cs =>
-      let evaluated' := evaluated ++ [c.name]
-      if c.fails then
-        (some c.err, evaluated')
-      else
-        go cs evaluated'
-  go checks []
+  evalOrderFrom checks []
 
 def checkValidationOrderVector (v : CVValidationOrderVector) : Bool :=
   let (firstErr, evaluated) := evalOrder v.checks

--- a/RubinFormal/FormalGap03.lean
+++ b/RubinFormal/FormalGap03.lean
@@ -1,0 +1,66 @@
+import RubinFormal.Conformance.CVValidationOrderReplay
+import RubinFormal.UtxoApplyGenesisV1
+
+namespace RubinFormal
+
+open RubinFormal.Conformance
+open RubinFormal.UtxoBasicV1
+open RubinFormal.UtxoApplyGenesisV1
+
+def det001ValidationOrderStatement : Prop :=
+  ∀ (before suffix : List ValidationCheck) (bad : ValidationCheck),
+    (∀ c ∈ before, c.fails = false) →
+    bad.fails = true →
+    evalOrder (before ++ bad :: suffix) =
+      (some bad.err, before.map ValidationCheck.name ++ [bad.name])
+
+def sem001MLDSAExactLengthStatement : Prop :=
+  ∀ (w : WitnessItem) (blockHeight : Nat),
+    w.suiteId = UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 →
+      (validateWitnessItemLengths w blockHeight = .ok () ↔
+        w.pubkey.size = UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES ∧
+        w.signature.size = UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES)
+
+theorem evalOrderFrom_first_failure
+    (evaluated : List String)
+    (before suffix : List ValidationCheck)
+    (bad : ValidationCheck)
+    (hBefore : ∀ c ∈ before, c.fails = false)
+    (hBad : bad.fails = true) :
+    evalOrderFrom (before ++ bad :: suffix) evaluated =
+      (some bad.err, evaluated ++ before.map ValidationCheck.name ++ [bad.name]) := by
+  induction before generalizing evaluated with
+  | nil =>
+      simp [Conformance.evalOrderFrom, hBad]
+  | cons c cs ih =>
+      have hc : c.fails = false := hBefore c (by simp)
+      have hcs : ∀ x ∈ cs, x.fails = false := by
+        intro x hx
+        exact hBefore x (by simp [hx])
+      have ih' := ih (evaluated ++ [c.name]) hcs
+      simpa [Conformance.evalOrderFrom, hc, List.map, List.append_assoc] using ih'
+
+theorem det001_validation_order_proved : det001ValidationOrderStatement := by
+  intro before suffix bad hBefore hBad
+  simpa [det001ValidationOrderStatement, Conformance.evalOrder] using
+    evalOrderFrom_first_failure [] before suffix bad hBefore hBad
+
+theorem sem001_mldsa_exact_lengths_proved : sem001MLDSAExactLengthStatement := by
+  intro w blockHeight hSuite
+  have hDistinct : ¬CovenantGenesisV1.SUITE_ID_ML_DSA_87 = CovenantGenesisV1.SUITE_ID_SENTINEL := by
+    native_decide
+  by_cases hPub : w.pubkey.size = UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES
+  · by_cases hSig : w.signature.size = UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES
+    · simp [sem001MLDSAExactLengthStatement, validateWitnessItemLengths, hSuite,
+        UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+        hDistinct, hPub, hSig]
+      change (Except.ok () : Except String Unit) = Except.ok ()
+      rfl
+    · simp [sem001MLDSAExactLengthStatement, validateWitnessItemLengths, hSuite,
+        UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+        hDistinct, hPub, hSig]
+  · simp [sem001MLDSAExactLengthStatement, validateWitnessItemLengths, hSuite,
+      UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+      hDistinct, hPub]
+
+end RubinFormal

--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -12,4 +12,5 @@ import RubinFormal.BlockBasicCheckV1
 import RubinFormal.SubsidyV1
 import RubinFormal.CovenantGenesisV1
 import RubinFormal.UtxoApplyGenesisV1
+import RubinFormal.FormalGap03
 import RubinFormal.Refinement.Index

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -13,7 +13,8 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_parse_vectors_pass",
-        "RubinFormal.Conformance.cv_compact_vectors_pass"
+        "RubinFormal.Conformance.cv_compact_vectors_pass",
+        "RubinFormal.sem001_mldsa_exact_lengths_proved"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean"
     },
@@ -59,7 +60,8 @@
       "section_heading": "## 13. Consensus Error Codes (Normative)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.Conformance.cv_validation_order_vectors_pass"
+        "RubinFormal.Conformance.cv_validation_order_vectors_pass",
+        "RubinFormal.det001_validation_order_proved"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean"
     },
@@ -114,7 +116,8 @@
       "section_heading": "## 18. UTXO State Model (Normative)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.Conformance.cv_utxo_basic_vectors_pass"
+        "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
+        "RubinFormal.det001_validation_order_proved"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean"
     },


### PR DESCRIPTION
## Summary\n- add DET-001 theorem for first-failure validation-order determinism\n- add SEM-001 theorem for exact ML-DSA witness lengths\n- sync proof coverage registry with the new theorem names\n\n## Validation\n- ~/.elan/bin/lake build\n- python3 -m json.tool proof_coverage.json >/dev/null\n\nRefs: Q-FORMAL-GAP-03, closes #22