### PR TITLE
feat(formal): VaultStateMachine lifecycle + ConnectBlockStrong proofs

### DIFF
--- a/RubinFormal/ConnectBlockStrong.lean
+++ b/RubinFormal/ConnectBlockStrong.lean
@@ -1,0 +1,266 @@
+import RubinFormal.SubsidyV1
+
+namespace RubinFormal
+
+open RubinFormal
+open RubinFormal.UtxoBasicV1
+open RubinFormal.SubsidyV1
+
+def inputs_available
+    (tx : Tx)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat) : Prop :=
+  ∃ inputState, scanInputs tx.inputs utxoMap height = .ok inputState
+
+def utxo_conserved_tx
+    (tx : Tx)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat)
+    (fee : Nat) : Prop :=
+  ∃ inputState,
+    scanInputs tx.inputs utxoMap height = .ok inputState ∧
+    inputState.sumIn = sumOutputs tx.outputs + fee
+
+def utxo_conserved
+    (txs : List Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes) : Prop :=
+  match txs with
+  | [] => True
+  | txBytes :: rest =>
+      ∃ prepared,
+        prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared ∧
+        utxo_conserved_tx prepared.tx utxoMap height prepared.fee ∧
+        utxo_conserved rest prepared.nextUtxoMap height blockTimestamp chainId
+
+def no_double_spend
+    (txs : List Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes) : Prop :=
+  match txs with
+  | [] => True
+  | txBytes :: rest =>
+      ∃ prepared,
+        prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared ∧
+        inputs_available prepared.tx utxoMap height ∧
+        no_double_spend rest prepared.nextUtxoMap height blockTimestamp chainId
+
+theorem applyNonCoinbaseTxBasicState_success_prepared
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (fee : Nat)
+    (next : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (hApply :
+      applyNonCoinbaseTxBasicState txBytes utxoMap height blockTimestamp chainId = .ok (fee, next)) :
+    ∃ prepared,
+      prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared ∧
+      prepared.fee = fee ∧
+      prepared.nextUtxoMap = next := by
+  unfold applyNonCoinbaseTxBasicState at hApply
+  cases hPrep : prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId with
+  | error e =>
+      simp [hPrep] at hApply
+      cases hApply
+  | ok prepared =>
+      simp [hPrep] at hApply
+      cases hApply
+      exact ⟨prepared, rfl, rfl, rfl⟩
+
+theorem except_bind_eq_ok
+    {ε α β : Type}
+    {x : Except ε α}
+    {f : α → Except ε β}
+    {y : β}
+    (h : x >>= f = .ok y) :
+    ∃ a, x = .ok a ∧ f a = .ok y := by
+  cases x with
+  | error e =>
+      cases h
+  | ok a =>
+      exact ⟨a, rfl, h⟩
+
+theorem computeBasicFee_success
+    (tx : Tx)
+    (inputState : InputScanState)
+    (fee : Nat)
+    (hFee : computeBasicFee tx inputState = .ok fee) :
+    inputState.sumIn = sumOutputs tx.outputs + fee := by
+  unfold computeBasicFee at hFee
+  by_cases hTooBig : sumOutputs tx.outputs > inputState.sumIn
+  · simp [hTooBig] at hFee
+    cases hFee
+  · simp [hTooBig] at hFee
+    cases hFee
+    omega
+
+theorem prepareNonCoinbaseTxBasic_success_core
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (prepared : PreparedNonCoinbaseTx)
+    (hPrep : prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared) :
+    ∃ core,
+      prepareNonCoinbaseTxCore txBytes utxoMap height blockTimestamp chainId = .ok core ∧
+      prepared =
+        {
+          tx := core.tx
+          inputState := core.inputState
+          fee := core.fee
+          nextUtxoMap :=
+            insertOutputs (eraseInputs utxoMap core.tx.inputs)
+              (match (TxV2.parseTx txBytes).txid with
+              | some t => t
+              | none => SHA3.sha3_256 ByteArray.empty)
+              core.tx.outputs height
+        } := by
+  unfold prepareNonCoinbaseTxBasic at hPrep
+  rcases except_bind_eq_ok hPrep with ⟨core, hCore, hPure⟩
+  simp at hPure
+  cases hPure
+  exact ⟨core, hCore, rfl⟩
+
+theorem prepareNonCoinbaseTxCore_success_components
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (core : PreparedNonCoinbaseTxCore)
+    (hCore : prepareNonCoinbaseTxCore txBytes utxoMap height blockTimestamp chainId = .ok core) :
+    ∃ tx inputState,
+      core.tx = tx ∧
+      core.inputState = inputState ∧
+      parseTx txBytes = .ok tx ∧
+      scanInputs tx.inputs utxoMap height = .ok inputState ∧
+      computeBasicFee tx inputState = .ok core.fee := by
+  unfold prepareNonCoinbaseTxCore at hCore
+  rcases except_bind_eq_ok hCore with ⟨tx, hParse, hRest1⟩
+  rcases except_bind_eq_ok hRest1 with ⟨_u1, _hEnv, hRest2⟩
+  rcases except_bind_eq_ok hRest2 with ⟨_u2, _hStruct, hRest3⟩
+  rcases except_bind_eq_ok hRest3 with ⟨inputState, hScan, hRest4⟩
+  rcases except_bind_eq_ok hRest4 with ⟨_u3, _hWitness, hRest5⟩
+  rcases except_bind_eq_ok hRest5 with ⟨_u4, _hVault, hRest6⟩
+  rcases except_bind_eq_ok hRest6 with ⟨fee, hFee, hPure⟩
+  cases hPure
+  exact ⟨tx, inputState, rfl, rfl, hParse, hScan, hFee⟩
+
+theorem prepareNonCoinbaseTxBasic_utxo_conserved
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (prepared : PreparedNonCoinbaseTx)
+    (hPrep : prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared) :
+    utxo_conserved_tx prepared.tx utxoMap height prepared.fee := by
+  rcases prepareNonCoinbaseTxBasic_success_core
+      txBytes utxoMap height blockTimestamp chainId prepared hPrep with
+    ⟨core, hCore, hPreparedEq⟩
+  cases hPreparedEq
+  rcases prepareNonCoinbaseTxCore_success_components
+      txBytes utxoMap height blockTimestamp chainId core hCore with
+    ⟨tx, inputState, hTxEq, hInputEq, hParse, hScan, hFeeCore⟩
+  cases hTxEq
+  cases hInputEq
+  refine ⟨core.inputState, hScan, ?_⟩
+  exact computeBasicFee_success core.tx core.inputState core.fee hFeeCore
+
+theorem prepareNonCoinbaseTxBasic_inputs_available
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (prepared : PreparedNonCoinbaseTx)
+    (hPrep : prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared) :
+    inputs_available prepared.tx utxoMap height := by
+  rcases prepareNonCoinbaseTxBasic_success_core
+      txBytes utxoMap height blockTimestamp chainId prepared hPrep with
+    ⟨core, hCore, hPreparedEq⟩
+  cases hPreparedEq
+  rcases prepareNonCoinbaseTxCore_success_components
+      txBytes utxoMap height blockTimestamp chainId core hCore with
+    ⟨tx, inputState, hTxEq, hInputEq, hParse, hScan, hFeeCore⟩
+  cases hTxEq
+  cases hInputEq
+  exact ⟨core.inputState, hScan⟩
+
+theorem utxo_conservation_theorem
+    (txs : List Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (sumFees : Nat)
+    (finalMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (hConnect :
+      connectBlockTxs txs utxoMap height blockTimestamp chainId = .ok (sumFees, finalMap)) :
+    utxo_conserved txs utxoMap height blockTimestamp chainId := by
+  induction txs generalizing utxoMap sumFees finalMap with
+  | nil =>
+      simp [utxo_conserved]
+  | cons tx rest ih =>
+      cases hStep : applyNonCoinbaseTxBasicState tx utxoMap height blockTimestamp chainId with
+      | error e =>
+          simp [connectBlockTxs, hStep] at hConnect
+      | ok step =>
+          cases step with
+          | mk fee next =>
+              cases hTail : connectBlockTxs rest next height blockTimestamp chainId with
+              | error e =>
+                  simp [connectBlockTxs, hStep, hTail] at hConnect
+              | ok tail =>
+                  cases tail with
+                  | mk feesTail finalTail =>
+                      simp [connectBlockTxs, hStep, hTail] at hConnect
+                      cases hConnect
+                      rcases applyNonCoinbaseTxBasicState_success_prepared
+                          tx utxoMap height blockTimestamp chainId fee next hStep with
+                        ⟨prepared, hPrep, hFeeEq, hNextEq⟩
+                      cases hFeeEq
+                      cases hNextEq
+                      refine ⟨prepared, hPrep, ?_, ?_⟩
+                      · exact prepareNonCoinbaseTxBasic_utxo_conserved
+                          tx utxoMap height blockTimestamp chainId prepared hPrep
+                      · exact ih prepared.nextUtxoMap feesTail finalTail hTail
+
+theorem no_double_spend_theorem
+    (txs : List Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (sumFees : Nat)
+    (finalMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (hConnect :
+      connectBlockTxs txs utxoMap height blockTimestamp chainId = .ok (sumFees, finalMap)) :
+    no_double_spend txs utxoMap height blockTimestamp chainId := by
+  induction txs generalizing utxoMap sumFees finalMap with
+  | nil =>
+      simp [no_double_spend]
+  | cons tx rest ih =>
+      cases hStep : applyNonCoinbaseTxBasicState tx utxoMap height blockTimestamp chainId with
+      | error e =>
+          simp [connectBlockTxs, hStep] at hConnect
+      | ok step =>
+          cases step with
+          | mk fee next =>
+              cases hTail : connectBlockTxs rest next height blockTimestamp chainId with
+              | error e =>
+                  simp [connectBlockTxs, hStep, hTail] at hConnect
+              | ok tail =>
+                  cases tail with
+                  | mk feesTail finalTail =>
+                      simp [connectBlockTxs, hStep, hTail] at hConnect
+                      cases hConnect
+                      rcases applyNonCoinbaseTxBasicState_success_prepared
+                          tx utxoMap height blockTimestamp chainId fee next hStep with
+                        ⟨prepared, hPrep, hFeeEq, hNextEq⟩
+                      cases hFeeEq
+                      cases hNextEq
+                      refine ⟨prepared, hPrep, ?_, ?_⟩
+                      · exact prepareNonCoinbaseTxBasic_inputs_available
+                          tx utxoMap height blockTimestamp chainId prepared hPrep
+                      · exact ih prepared.nextUtxoMap feesTail finalTail hTail
+
+end RubinFormal

--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -7,9 +7,11 @@ import RubinFormal.SighashV1
 import RubinFormal.PowV1
 import RubinFormal.TxWeightV2
 import RubinFormal.UtxoBasicV1
+import RubinFormal.VaultStateMachine
 import RubinFormal.BlockBasicV1
 import RubinFormal.BlockBasicCheckV1
 import RubinFormal.SubsidyV1
+import RubinFormal.ConnectBlockStrong
 import RubinFormal.CovenantGenesisV1
 import RubinFormal.UtxoApplyGenesisV1
 import RubinFormal.FormalGap03

--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -261,6 +261,259 @@ def sumOutputs (outs : List TxOut) : Nat :=
 def buildUtxoMap (utxos : List (Outpoint × UtxoEntry)) : Std.RBMap Outpoint UtxoEntry cmpOutpoint :=
   utxos.foldl (fun m (p : Outpoint × UtxoEntry) => m.insert p.fst p.snd) (Std.RBMap.empty)
 
+def txInOutpoint (i : TxIn) : Outpoint :=
+  { txid := i.prevTxid, vout := i.prevVout }
+
+def txConsumedOutpoints (tx : Tx) : List Outpoint :=
+  tx.inputs.map txInOutpoint
+
+def inputValueSum
+    (inputs : List TxIn)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint) : Except String Nat := do
+  match inputs with
+  | [] => pure 0
+  | i :: rest =>
+      let op := txInOutpoint i
+      let e ←
+        match utxoMap.find? op with
+        | none => throw "TX_ERR_MISSING_UTXO"
+        | some x => pure x
+      let tail := inputValueSum rest utxoMap
+      pure (e.value + (← tail))
+
+def validateStructuralInputs (inputs : List TxIn) : Except String Unit := do
+  match inputs with
+  | [] => pure ()
+  | i :: rest =>
+      if i.scriptSig.size != 0 then throw "TX_ERR_PARSE"
+      if i.sequence > 0x7fffffff then throw "TX_ERR_SEQUENCE_INVALID"
+      if isCoinbasePrevout i then throw "TX_ERR_PARSE"
+      validateStructuralInputs rest
+
+structure InputScanState where
+  sumIn : Nat
+  sumInVault : Nat
+  vaultWhitelist : List Bytes
+  vaultOwnerLockId : Option Bytes
+  vaultInputs : Nat
+  inputLockIds : List Bytes
+  inputCovTypes : List Nat
+  requiredWitnessSlots : Nat
+  consumedOutpoints : List Outpoint
+deriving Repr
+
+def InputScanState.empty : InputScanState :=
+  {
+    sumIn := 0
+    sumInVault := 0
+    vaultWhitelist := []
+    vaultOwnerLockId := none
+    vaultInputs := 0
+    inputLockIds := []
+    inputCovTypes := []
+    requiredWitnessSlots := 0
+    consumedOutpoints := []
+  }
+
+structure PreparedNonCoinbaseTx where
+  tx : Tx
+  inputState : InputScanState
+  fee : Nat
+  nextUtxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint
+
+structure PreparedNonCoinbaseTxCore where
+  tx : Tx
+  inputState : InputScanState
+  fee : Nat
+
+def scanSingleInputStep
+    (input : TxIn)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat)
+    (acc : InputScanState) : Except String InputScanState := do
+  let op := txInOutpoint input
+  if acc.consumedOutpoints.contains op then
+    throw "TX_ERR_PARSE"
+  let e ←
+    match utxoMap.find? op with
+    | none => throw "TX_ERR_MISSING_UTXO"
+    | some x => pure x
+
+  if e.covenantType == COV_TYPE_ANCHOR || e.covenantType == COV_TYPE_DA_COMMIT then
+    throw "TX_ERR_MISSING_UTXO"
+
+  if e.createdByCoinbase then
+    if height < e.creationHeight + COINBASE_MATURITY then
+      throw "TX_ERR_COINBASE_IMMATURE"
+
+  if e.covenantType == COV_TYPE_P2PK then
+    if e.covenantData.size != MAX_P2PK_COVENANT_DATA then
+      throw "TX_ERR_COVENANT_TYPE_INVALID"
+    let suite := (e.covenantData.get! 0).toNat
+    if suite != SUITE_ID_ML_DSA_87 then
+      throw "TX_ERR_COVENANT_TYPE_INVALID"
+
+  let lockId := outputDescriptorLockId e
+  let mut nextAcc :=
+    { acc with
+        sumIn := acc.sumIn + e.value
+        inputLockIds := acc.inputLockIds.concat lockId
+        inputCovTypes := acc.inputCovTypes.concat e.covenantType
+        consumedOutpoints := acc.consumedOutpoints.concat op
+    }
+
+  if e.covenantType == COV_TYPE_VAULT then
+    let v ← CovenantGenesisV1.parseVaultCovenantData e.covenantData
+    let nextVaultInputs := nextAcc.vaultInputs + 1
+    if nextVaultInputs > 1 then
+      throw "TX_ERR_VAULT_MULTI_INPUT_FORBIDDEN"
+    nextAcc :=
+      { nextAcc with
+          requiredWitnessSlots := nextAcc.requiredWitnessSlots + v.keyCount
+          sumInVault := e.value
+          vaultOwnerLockId := some v.ownerLockId
+          vaultWhitelist := v.whitelist
+          vaultInputs := nextVaultInputs
+      }
+  else
+    nextAcc :=
+      { nextAcc with requiredWitnessSlots := nextAcc.requiredWitnessSlots + 1 }
+
+  pure nextAcc
+
+def scanInputsGo
+    (inputs : List TxIn)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat)
+    (acc : InputScanState) : Except String InputScanState := do
+  match inputs with
+  | [] => pure acc
+  | i :: rest =>
+      let nextAcc ← scanSingleInputStep i utxoMap height acc
+      scanInputsGo rest utxoMap height nextAcc
+
+def scanInputs
+    (inputs : List TxIn)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat) : Except String InputScanState :=
+  scanInputsGo inputs utxoMap height InputScanState.empty
+
+def eraseInputs
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (inputs : List TxIn) : Std.RBMap Outpoint UtxoEntry cmpOutpoint :=
+  inputs.foldl (fun next i => next.erase (txInOutpoint i)) utxoMap
+
+def insertOutputs
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (txid : Bytes)
+    (outputs : List TxOut)
+    (height : Nat) : Std.RBMap Outpoint UtxoEntry cmpOutpoint :=
+  let rec go
+      (outs : List TxOut)
+      (next : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+      (vout : Nat) : Std.RBMap Outpoint UtxoEntry cmpOutpoint :=
+    match outs with
+    | [] => next
+    | o :: rest =>
+        let op : Outpoint := { txid := txid, vout := vout }
+        let next' :=
+          next.insert op
+            {
+              value := o.value
+              covenantType := o.covenantType
+              covenantData := o.covenantData
+              creationHeight := height
+              createdByCoinbase := false
+            }
+        go rest next' (vout + 1)
+  go outputs utxoMap 0
+
+def validateBasicWitnessLayout
+    (tx : Tx)
+    (inputState : InputScanState) : Except String Unit := do
+  if tx.witness.length != inputState.requiredWitnessSlots then
+    throw "TX_ERR_PARSE"
+  pure ()
+
+def validateBasicTxEnvelope (tx : Tx) : Except String Unit := do
+  if tx.inputs.length == 0 then
+    throw "TX_ERR_PARSE"
+  if tx.txNonce == 0 then
+    throw "TX_ERR_TX_NONCE_INVALID"
+  pure ()
+
+def validateBasicVaultSpend
+    (tx : Tx)
+    (inputState : InputScanState) : Except String Unit := do
+  if inputState.vaultInputs == 1 then
+    let owner ←
+      match inputState.vaultOwnerLockId with
+      | none => throw "TX_ERR_VAULT_MALFORMED"
+      | some x => pure x
+
+    let mut haveOwner : Bool := false
+    for (lid, cov) in List.zip inputState.inputLockIds inputState.inputCovTypes do
+      if cov != COV_TYPE_VAULT && lid == owner then
+        haveOwner := true
+    if !haveOwner then
+      throw "TX_ERR_VAULT_OWNER_AUTH_REQUIRED"
+
+    for o in tx.outputs do
+      if o.covenantType == COV_TYPE_VAULT then
+        throw "TX_ERR_VAULT_OUTPUT_NOT_WHITELISTED"
+      let h := RubinFormal.OutputDescriptor.hash o.covenantType o.covenantData
+      if !(inputState.vaultWhitelist.contains h) then
+        throw "TX_ERR_VAULT_OUTPUT_NOT_WHITELISTED"
+
+    let sumOut := sumOutputs tx.outputs
+    if sumOut < inputState.sumInVault then
+      throw "TX_ERR_VALUE_CONSERVATION"
+  pure ()
+
+def computeBasicFee
+    (tx : Tx)
+    (inputState : InputScanState) : Except String Nat := do
+  let sumOutAll := sumOutputs tx.outputs
+  if sumOutAll > inputState.sumIn then
+    throw "TX_ERR_VALUE_CONSERVATION"
+  pure (inputState.sumIn - sumOutAll)
+
+def prepareNonCoinbaseTxCore
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat)
+    (blockTimestamp : Nat)
+    (chainId : Bytes) : Except String PreparedNonCoinbaseTxCore := do
+  let _ := blockTimestamp
+  let _ := chainId
+  let tx ← parseTx txBytes
+
+  validateBasicTxEnvelope tx
+  validateStructuralInputs tx.inputs
+  let inputState ← scanInputs tx.inputs utxoMap height
+
+  validateBasicWitnessLayout tx inputState
+  validateBasicVaultSpend tx inputState
+  let fee ← computeBasicFee tx inputState
+  pure { tx := tx, inputState := inputState, fee := fee }
+
+def prepareNonCoinbaseTxBasic
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height : Nat)
+    (blockTimestamp : Nat)
+    (chainId : Bytes) : Except String PreparedNonCoinbaseTx := do
+  let core ← prepareNonCoinbaseTxCore txBytes utxoMap height blockTimestamp chainId
+
+  let txid :=
+    let r := RubinFormal.TxV2.parseTx txBytes
+    match r.txid with
+    | some t => t
+    | none => SHA3.sha3_256 ByteArray.empty
+
+  let next := insertOutputs (eraseInputs utxoMap core.tx.inputs) txid core.tx.outputs height
+  pure { tx := core.tx, inputState := core.inputState, fee := core.fee, nextUtxoMap := next }
+
 -- NOTE: This is intentionally simplified for formal replay:
 -- we enforce all pre-signature rules and binding rules, but we treat cryptographic signature
 -- verification as an out-of-scope predicate (handled by Go↔Rust + OpenSSL in conformance).
@@ -270,134 +523,8 @@ def applyNonCoinbaseTxBasicState
     (height : Nat)
     (blockTimestamp : Nat)
     (chainId : Bytes) : Except String (Nat × Std.RBMap Outpoint UtxoEntry cmpOutpoint) := do
-  let _ := blockTimestamp
-  let tx ← parseTx txBytes
-
-  if tx.inputs.length == 0 then throw "TX_ERR_PARSE"
-  if tx.txNonce == 0 then throw "TX_ERR_TX_NONCE_INVALID"
-
-  -- structural input checks (subset)
-  for i in tx.inputs do
-    if i.scriptSig.size != 0 then throw "TX_ERR_PARSE"
-    if i.sequence > 0x7fffffff then throw "TX_ERR_SEQUENCE_INVALID"
-    if isCoinbasePrevout i then throw "TX_ERR_PARSE"
-
-  -- gather sums and vault context
-  let mut sumIn : Nat := 0
-  let mut sumInVault : Nat := 0
-  let mut vaultWhitelist : List Bytes := []
-  let mut vaultOwnerLockId : Option Bytes := none
-  let mut vaultInputs : Nat := 0
-  let mut inputLockIds : List Bytes := []
-  let mut inputCovTypes : List Nat := []
-  let mut requiredWitnessSlots : Nat := 0
-
-  -- require unique outpoints
-  let mut seen : Std.RBSet Outpoint cmpOutpoint := Std.RBSet.empty
-
-  for i in tx.inputs do
-    let op : Outpoint := { txid := i.prevTxid, vout := i.prevVout }
-    if seen.contains op then throw "TX_ERR_PARSE"
-    seen := seen.insert op
-    let e? := utxoMap.find? op
-    let e ← match e? with
-      | none => throw "TX_ERR_MISSING_UTXO"
-      | some x => pure x
-
-    if e.covenantType == COV_TYPE_ANCHOR || e.covenantType == COV_TYPE_DA_COMMIT then
-      throw "TX_ERR_MISSING_UTXO"
-
-    if e.createdByCoinbase then
-      if height < e.creationHeight + COINBASE_MATURITY then
-        throw "TX_ERR_COINBASE_IMMATURE"
-
-    -- P2PK suite gating (needed for CV-SIG-* and UTXO-basic replay correctness).
-    if e.covenantType == COV_TYPE_P2PK then
-      if e.covenantData.size != MAX_P2PK_COVENANT_DATA then
-        throw "TX_ERR_COVENANT_TYPE_INVALID"
-      let suite := (e.covenantData.get! 0).toNat
-      if suite != SUITE_ID_ML_DSA_87 then
-        throw "TX_ERR_COVENANT_TYPE_INVALID"
-
-    let lockId := outputDescriptorLockId e
-    inputLockIds := inputLockIds.concat lockId
-    inputCovTypes := inputCovTypes.concat e.covenantType
-
-    sumIn := sumIn + e.value
-    -- witness cursor model (minimal): P2PK consumes 1 slot; VAULT consumes key_count slots.
-    if e.covenantType == COV_TYPE_VAULT then
-      let v ← CovenantGenesisV1.parseVaultCovenantData e.covenantData
-      requiredWitnessSlots := requiredWitnessSlots + v.keyCount
-    else
-      requiredWitnessSlots := requiredWitnessSlots + 1
-
-    if e.covenantType == COV_TYPE_VAULT then
-      vaultInputs := vaultInputs + 1
-      if vaultInputs > 1 then
-        throw "TX_ERR_VAULT_MULTI_INPUT_FORBIDDEN"
-      sumInVault := e.value
-      let v ← CovenantGenesisV1.parseVaultCovenantData e.covenantData
-      vaultOwnerLockId := some v.ownerLockId
-      vaultWhitelist := v.whitelist
-
-  if tx.witness.length != requiredWitnessSlots then
-    throw "TX_ERR_PARSE"
-
-  -- CORE_VAULT rules used by CV-UTXO-BASIC vectors
-  if vaultInputs == 1 then
-    let owner ←
-      match vaultOwnerLockId with
-      | none => throw "TX_ERR_VAULT_MALFORMED"
-      | some x => pure x
-
-    -- owner-authorization required: at least one non-vault input must have lock_id == owner lock
-    let mut haveOwner : Bool := false
-    for (lid, cov) in List.zip inputLockIds inputCovTypes do
-      if cov != COV_TYPE_VAULT && lid == owner then
-        haveOwner := true
-    if !haveOwner then
-      throw "TX_ERR_VAULT_OWNER_AUTH_REQUIRED"
-
-    -- whitelist membership: every output descriptor hash must be in whitelist
-    for o in tx.outputs do
-      -- vault recursion is forbidden: a vault-spend must not create CORE_VAULT outputs
-      if o.covenantType == COV_TYPE_VAULT then
-        throw "TX_ERR_VAULT_OUTPUT_NOT_WHITELISTED"
-      let h := RubinFormal.OutputDescriptor.hash o.covenantType o.covenantData
-      if !(vaultWhitelist.contains h) then
-        throw "TX_ERR_VAULT_OUTPUT_NOT_WHITELISTED"
-
-    -- value rule: vault value must not fund fee
-    let sumOut := sumOutputs tx.outputs
-    if sumOut < sumInVault then
-      throw "TX_ERR_VALUE_CONSERVATION"
-
-  -- value conservation
-  let sumOutAll := sumOutputs tx.outputs
-  if sumOutAll > sumIn then throw "TX_ERR_VALUE_CONSERVATION"
-  let fee := sumIn - sumOutAll
-
-  -- update UTXO count: remove spent, add outputs
-  let mut next : Std.RBMap Outpoint UtxoEntry cmpOutpoint := utxoMap
-  for i in tx.inputs do
-    let op : Outpoint := { txid := i.prevTxid, vout := i.prevVout }
-    next := next.erase op
-
-  -- txid is consensus identifier = SHA3-256(TxCoreBytes(T)); we reuse Sighash parser core slice as proxy:
-  -- in these vectors tx_kind=0x00 and DaCoreFieldsBytes is empty, so TxCoreBytes ends at locktime.
-  let txid :=
-    let r := RubinFormal.TxV2.parseTx txBytes
-    match r.txid with
-    | some t => t
-    | none => SHA3.sha3_256 ByteArray.empty
-
-  let mut vout : Nat := 0
-  for o in tx.outputs do
-    let op : Outpoint := { txid := txid, vout := vout }
-    next := next.insert op { value := o.value, covenantType := o.covenantType, covenantData := o.covenantData, creationHeight := height, createdByCoinbase := false }
-    vout := vout + 1
-
-  pure (fee, next)
+  let prepared ← prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId
+  pure (prepared.fee, prepared.nextUtxoMap)
 
 def applyNonCoinbaseTxBasic
     (txBytes : Bytes)

--- a/RubinFormal/VaultStateMachine.lean
+++ b/RubinFormal/VaultStateMachine.lean
@@ -1,0 +1,92 @@
+import RubinFormal.CovenantGenesisV1
+import RubinFormal.Conformance.CVVaultPolicyReplay
+
+namespace RubinFormal
+
+/-- Policy-level lifecycle for a `CORE_VAULT` output. -/
+inductive VaultState where
+  | created
+  | triggered
+  | swept
+  | cancelled
+  deriving DecidableEq, Repr
+
+/-- Lifecycle actions. `wait` is an explicit stutter step so every state
+    admits at least one valid transition in the model. -/
+inductive VaultAction where
+  | trigger
+  | sweep (lockMode lockValue blockHeight blockMtp : Nat)
+  | cancel
+  | wait
+  deriving DecidableEq, Repr
+
+def vaultTransition : VaultState -> VaultAction -> Option VaultState
+  | .created, .trigger => some .triggered
+  | .created, .cancel => some .cancelled
+  | .created, .wait => some .created
+  | .triggered, .sweep lockMode lockValue blockHeight blockMtp =>
+      if CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp then
+        some .swept
+      else
+        none
+  | .triggered, .wait => some .triggered
+  | .swept, .wait => some .swept
+  | .cancelled, .wait => some .cancelled
+  | _, _ => none
+
+theorem triggered_implies_sweepable
+    (lockMode lockValue blockHeight blockMtp : Nat)
+    (h : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = true) :
+    vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = some .swept := by
+  simp [vaultTransition, h]
+
+theorem cancelled_implies_not_sweepable
+    (lockMode lockValue blockHeight blockMtp : Nat) :
+    vaultTransition .cancelled (.sweep lockMode lockValue blockHeight blockMtp) = none := by
+  rfl
+
+theorem no_dead_states : ∀ s : VaultState, ∃ a next, vaultTransition s a = some next := by
+  intro s
+  cases s with
+  | created =>
+      exact ⟨VaultAction.trigger, VaultState.triggered, rfl⟩
+  | triggered =>
+      exact ⟨VaultAction.wait, VaultState.triggered, rfl⟩
+  | swept =>
+      exact ⟨VaultAction.wait, VaultState.swept, rfl⟩
+  | cancelled =>
+      exact ⟨VaultAction.wait, VaultState.cancelled, rfl⟩
+
+theorem timelock_enforced
+    (lockMode lockValue blockHeight blockMtp : Nat)
+    (h : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = false) :
+    vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = none := by
+  simp [vaultTransition, h]
+
+/-- Bridge theorem to keep the lifecycle model aligned with the existing vault
+    policy replay model used in conformance proofs. -/
+theorem triggered_sweep_consistent_with_vault_policy
+    (v : Conformance.CVVaultPolicyVector)
+    (lockMode lockValue blockHeight blockMtp : Nat)
+    (hOrder : v.validationOrder = none)
+    (hMulti : v.vaultInputCount <= 1)
+    (hOwner : v.hasOwnerAuth = true)
+    (hSponsor : (v.nonVaultLockIds.all (fun x => x == v.ownerLockId)) = true)
+    (hSlots : (v.slots == v.keyCount) = true)
+    (hSentinel :
+      (v.sentinelSuiteId == 0 &&
+        v.sentinelPubkeyLen == 0 &&
+        v.sentinelSigLen == 0 &&
+        (!v.sentinelVerifyCalled)) = true)
+    (hSig : v.sigThresholdOk = true)
+    (hWhitelist : Conformance.strictlySortedUnique v.whitelist = true)
+    (hValue : v.sumOut >= v.sumInVault)
+    (hTimelock : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = true) :
+    vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = some .swept ∧
+      Conformance.vaultPolicyEval v = (true, none) := by
+  constructor
+  · exact triggered_implies_sweepable lockMode lockValue blockHeight blockMtp hTimelock
+  · exact Conformance.vault_policy_default_order_safe_proved
+      v hOrder hMulti hOwner hSponsor hSlots hSentinel hSig hWhitelist hValue
+
+end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -129,11 +129,19 @@
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
         "RubinFormal.det001_validation_order_proved",
-        "RubinFormal.Conformance.vault_policy_default_order_safe_proved"
+        "RubinFormal.Conformance.vault_policy_default_order_safe_proved",
+        "RubinFormal.triggered_implies_sweepable",
+        "RubinFormal.cancelled_implies_not_sweepable",
+        "RubinFormal.no_dead_states",
+        "RubinFormal.timelock_enforced"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
-        "RubinFormal.Conformance.vault_policy_default_order_safe_proved": "rubin-formal/RubinFormal/Conformance/CVVaultPolicyReplay.lean"
+        "RubinFormal.Conformance.vault_policy_default_order_safe_proved": "rubin-formal/RubinFormal/Conformance/CVVaultPolicyReplay.lean",
+        "RubinFormal.triggered_implies_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
+        "RubinFormal.cancelled_implies_not_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
+        "RubinFormal.no_dead_states": "rubin-formal/RubinFormal/VaultStateMachine.lean",
+        "RubinFormal.timelock_enforced": "rubin-formal/RubinFormal/VaultStateMachine.lean"
       }
     },
     {
@@ -141,9 +149,15 @@
       "section_heading": "## 25. Block Validation Order (Normative)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.SubsidyV1.connectBlock_end_to_end_proved"
+        "RubinFormal.SubsidyV1.connectBlock_end_to_end_proved",
+        "RubinFormal.utxo_conservation_theorem",
+        "RubinFormal.no_double_spend_theorem"
       ],
-      "file": "rubin-formal/RubinFormal/SubsidyV1.lean"
+      "file": "rubin-formal/RubinFormal/SubsidyV1.lean",
+      "theorem_files": {
+        "RubinFormal.utxo_conservation_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
+        "RubinFormal.no_double_spend_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean"
+      }
     },
     {
       "section_key": "value_conservation",
@@ -151,9 +165,13 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
-        "RubinFormal.Conformance.cv_subsidy_vectors_pass"
+        "RubinFormal.Conformance.cv_subsidy_vectors_pass",
+        "RubinFormal.utxo_conservation_theorem"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean"
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "theorem_files": {
+        "RubinFormal.utxo_conservation_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean"
+      }
     },
     {
       "section_key": "da_set_integrity",


### PR DESCRIPTION
## Summary

- **VaultStateMachine.lean**: Vault lifecycle state machine with 4 safety theorems + bridge theorem to conformance replay
- **ConnectBlockStrong.lean**: `utxo_conservation_theorem` and `no_double_spend_theorem` — if `connectBlockTxs` succeeds, every transaction satisfies value conservation and input availability
- **UtxoBasicV1.lean**: Exported additional definitions needed by ConnectBlockStrong
- **Review fixes**: Removed dead code (`UtxoFiniteMap` etc.), removed duplicate predicate `no_double_spend_tx`, simplified `no_double_spend` definition

## Verification

- `lake build` 300/300, 0 errors, 0 sorry
- Code review: 2 findings fixed (F1: duplicate predicate, F2: dead code)

## Refs

Q-COUNCIL-H18-SM, Q-FORMAL-CONNECTBLOCK-STRONG