### PR TITLE
fix: track CVVaultLifecycleReplay in proof_coverage.json

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -134,7 +134,10 @@
         "RubinFormal.cancelled_implies_not_sweepable",
         "RubinFormal.no_dead_states",
         "RubinFormal.timelock_enforced",
-        "RubinFormal.triggered_sweep_consistent_with_vault_policy"
+        "RubinFormal.triggered_sweep_consistent_with_vault_policy",
+        "RubinFormal.Conformance.cv_vault_with_lifecycle_pass",
+        "RubinFormal.Conformance.vault_full_lifecycle_valid",
+        "RubinFormal.Conformance.vault_cancel_lifecycle_valid"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -143,7 +146,10 @@
         "RubinFormal.cancelled_implies_not_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.no_dead_states": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.timelock_enforced": "rubin-formal/RubinFormal/VaultStateMachine.lean",
-        "RubinFormal.triggered_sweep_consistent_with_vault_policy": "rubin-formal/RubinFormal/VaultStateMachine.lean"
+        "RubinFormal.triggered_sweep_consistent_with_vault_policy": "rubin-formal/RubinFormal/VaultStateMachine.lean",
+        "RubinFormal.Conformance.cv_vault_with_lifecycle_pass": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
+        "RubinFormal.Conformance.vault_full_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
+        "RubinFormal.Conformance.vault_cancel_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Add 3 theorems from CVVaultLifecycleReplay.lean to utxo_state_model section

🤖 Generated with [Claude Code](https://claude.com/claude-code)