### PR TITLE
fix: align vault state machine model with sweep invariants

### DIFF
--- a/RubinFormal/Conformance/CVVaultLifecycleReplay.lean
+++ b/RubinFormal/Conformance/CVVaultLifecycleReplay.lean
@@ -5,13 +5,31 @@ namespace RubinFormal.Conformance
 
 open RubinFormal
 
+/-- Prefix-free fallback for existing vectors that still encode the lifecycle in
+    transaction structure instead of the ID. -/
+private def vaultLifecyclePhaseFromStructure (v : VaultVector) : Option VaultState :=
+  let spendsVault :=
+    v.utxos.any (fun u => u.covenantType == CovenantGenesisV1.COV_TYPE_VAULT)
+  let createsVault :=
+    match RubinFormal.decodeHex? v.txHex with
+    | some txBytes =>
+        match UtxoBasicV1.parseTx txBytes with
+        | .ok tx => tx.outputs.any (fun o => o.covenantType == CovenantGenesisV1.COV_TYPE_VAULT)
+        | .error _ => false
+    | none => false
+  if createsVault && !spendsVault then some .created
+  else if spendsVault then some .triggered
+  else none
+
 /-- Classify a CV-VAULT conformance vector by vault lifecycle phase.
     CREATE vectors → `.created` (vault output produced).
-    SPEND vectors  → `.triggered` (vault input being consumed). -/
+    SPEND vectors  → `.triggered` (vault input being consumed).
+    Non-prefixed vectors must still classify from concrete tx/UTXO structure;
+    otherwise the combined gate fails closed. -/
 def vaultLifecyclePhase (v : VaultVector) : Option VaultState :=
   if "VAULT-CREATE".isPrefixOf v.id then some .created
   else if "VAULT-SPEND".isPrefixOf v.id then some .triggered
-  else none
+  else vaultLifecyclePhaseFromStructure v
 
 /-- Combined gate: each CV-VAULT conformance vector must pass both
     (1) transaction-level replay and
@@ -29,7 +47,7 @@ def vaultVectorWithLifecycle (v : VaultVector) : Bool :=
         else true
     | some .triggered =>
         (vaultTransition .triggered .wait).isSome
-    | _ => true
+    | _ => false
   txPass && smOk
 
 def cvVaultWithLifecyclePass : Bool :=
@@ -44,12 +62,14 @@ theorem cv_vault_with_lifecycle_pass : cvVaultWithLifecyclePass = true := by
     Valid whenever the HTLC timelock condition is satisfied. -/
 theorem vault_full_lifecycle_valid
     (lockMode lockValue blockHeight blockMtp : Nat)
+    (hMode : lockMode <= CovenantGenesisV1.LOCK_MODE_TIMESTAMP)
+    (hPositive : 0 < lockValue)
     (hTimelock : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = true) :
     vaultTransition .created .trigger = some .triggered ∧
     vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = some .swept := by
   constructor
   · rfl
-  · simp [vaultTransition, hTimelock]
+  · simp [vaultTransition, validSweepParams, hMode, hPositive, hTimelock]
 
 /-- Cancel lifecycle: created → cancelled, and cancelled blocks sweep. -/
 theorem vault_cancel_lifecycle_valid :

--- a/RubinFormal/VaultStateMachine.lean
+++ b/RubinFormal/VaultStateMachine.lean
@@ -20,13 +20,21 @@ inductive VaultAction where
   | wait
   deriving DecidableEq, Repr
 
+/-- Sweep parameters must satisfy the same wire-level bounds as the HTLC parser:
+    only modes `0`/`1` are valid and `lockValue` must be positive. -/
+def validSweepParams (lockMode lockValue : Nat) : Bool :=
+  (lockMode <= CovenantGenesisV1.LOCK_MODE_TIMESTAMP) && (0 < lockValue)
+
 def vaultTransition : VaultState -> VaultAction -> Option VaultState
   | .created, .trigger => some .triggered
   | .created, .cancel => some .cancelled
   | .created, .wait => some .created
   | .triggered, .sweep lockMode lockValue blockHeight blockMtp =>
-      if CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp then
-        some .swept
+      if validSweepParams lockMode lockValue then
+        if CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp then
+          some .swept
+        else
+          none
       else
         none
   | .triggered, .wait => some .triggered
@@ -36,9 +44,11 @@ def vaultTransition : VaultState -> VaultAction -> Option VaultState
 
 theorem triggered_implies_sweepable
     (lockMode lockValue blockHeight blockMtp : Nat)
+    (hMode : lockMode <= CovenantGenesisV1.LOCK_MODE_TIMESTAMP)
+    (hValue : 0 < lockValue)
     (h : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = true) :
     vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = some .swept := by
-  simp [vaultTransition, h]
+  simp [vaultTransition, validSweepParams, hMode, hValue, h]
 
 theorem cancelled_implies_not_sweepable
     (lockMode lockValue blockHeight blockMtp : Nat) :
@@ -61,11 +71,11 @@ theorem timelock_enforced
     (lockMode lockValue blockHeight blockMtp : Nat)
     (h : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = false) :
     vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = none := by
-  simp [vaultTransition, h]
+  simp [vaultTransition, validSweepParams, h]
 
-/-- Bridge theorem to keep the lifecycle model aligned with the existing vault
-    policy replay model used in conformance proofs. -/
-theorem triggered_sweep_consistent_with_vault_policy
+/-- Convenience bundle: the state-machine sweep check and the vault-policy replay
+    theorem are both available under their respective independent hypotheses. -/
+theorem vault_sweep_and_policy_independent_checks
     (v : Conformance.CVVaultPolicyVector)
     (lockMode lockValue blockHeight blockMtp : Nat)
     (hOrder : v.validationOrder = none)
@@ -81,11 +91,13 @@ theorem triggered_sweep_consistent_with_vault_policy
     (hSig : v.sigThresholdOk = true)
     (hWhitelist : Conformance.strictlySortedUnique v.whitelist = true)
     (hValue : v.sumOut >= v.sumInVault)
+    (hMode : lockMode <= CovenantGenesisV1.LOCK_MODE_TIMESTAMP)
+    (hPositive : 0 < lockValue)
     (hTimelock : CovenantGenesisV1.htlcTimelockMet lockMode lockValue blockHeight blockMtp = true) :
     vaultTransition .triggered (.sweep lockMode lockValue blockHeight blockMtp) = some .swept ∧
       Conformance.vaultPolicyEval v = (true, none) := by
   constructor
-  · exact triggered_implies_sweepable lockMode lockValue blockHeight blockMtp hTimelock
+  · exact triggered_implies_sweepable lockMode lockValue blockHeight blockMtp hMode hPositive hTimelock
   · exact Conformance.vault_policy_default_order_safe_proved
       v hOrder hMulti hOwner hSponsor hSlots hSentinel hSig hWhitelist hValue
 

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -134,7 +134,7 @@
         "RubinFormal.cancelled_implies_not_sweepable",
         "RubinFormal.no_dead_states",
         "RubinFormal.timelock_enforced",
-        "RubinFormal.triggered_sweep_consistent_with_vault_policy",
+        "RubinFormal.vault_sweep_and_policy_independent_checks",
         "RubinFormal.Conformance.cv_vault_with_lifecycle_pass",
         "RubinFormal.Conformance.vault_full_lifecycle_valid",
         "RubinFormal.Conformance.vault_cancel_lifecycle_valid"
@@ -146,7 +146,7 @@
         "RubinFormal.cancelled_implies_not_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.no_dead_states": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.timelock_enforced": "rubin-formal/RubinFormal/VaultStateMachine.lean",
-        "RubinFormal.triggered_sweep_consistent_with_vault_policy": "rubin-formal/RubinFormal/VaultStateMachine.lean",
+        "RubinFormal.vault_sweep_and_policy_independent_checks": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.Conformance.cv_vault_with_lifecycle_pass": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
         "RubinFormal.Conformance.vault_full_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
         "RubinFormal.Conformance.vault_cancel_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean"


### PR DESCRIPTION
## Summary
- add parser-aligned sweep guards to the vault state machine (lockMode <= 1, lockValue > 0)
- rename the bridge theorem so it explicitly describes bundled independent checks instead of implying end-to-end consistency
- update the dependent lifecycle theorem and proof registry to match the refined model

## Validation
- PATH="$HOME/.elan/bin:$PATH" lake build
- rg --files /Users/gpt/Documents/rubin-formal | rg "\.lean$" | xargs rg -n "\bsorry\b"
- python3 -m json.tool proof_coverage.json >/dev/null

Closes #40
Closes #41