### PR TITLE
fix: map duplicate tx inputs to TX_ERR_DUPLICATE_INPUT

### DIFF
--- a/RubinFormal/ConnectBlockStrong.lean
+++ b/RubinFormal/ConnectBlockStrong.lean
@@ -214,7 +214,7 @@ theorem scanSingleInputStep_not_contains
   | false => rfl
   | true =>
     exfalso
-    have herr : scanSingleInputStep input utxoMap height acc = Except.error "TX_ERR_PARSE" := by
+    have herr : scanSingleInputStep input utxoMap height acc = Except.error "TX_ERR_DUPLICATE_INPUT" := by
       unfold scanSingleInputStep
       simp only [hDup, ite_true, Bind.bind, Except.bind]
     rw [herr] at hStep

--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -333,7 +333,7 @@ def scanSingleInputStep
     (acc : InputScanState) : Except String InputScanState := do
   let op := txInOutpoint input
   if acc.consumedOutpoints.contains op then
-    throw "TX_ERR_PARSE"
+    throw "TX_ERR_DUPLICATE_INPUT"
   let e ←
     match utxoMap.find? op with
     | none => throw "TX_ERR_MISSING_UTXO"


### PR DESCRIPTION
## Summary
- return `TX_ERR_DUPLICATE_INPUT` when `scanSingleInputStep` sees the same outpoint twice in one transaction
- keep the existing consumed-outpoint tracking path and align `ConnectBlockStrong` proof with the new error mapping
- validate the change with `lake build`

## Validation
- `export PATH="$HOME/.elan/bin:$PATH" && lake build`

Refs F-AUDIT-06
Refs Q-AUDIT-FORMAL-02
