### PR TITLE
fix: correct YAML indentation in models-lean-review.yml

### DIFF
--- a/.github/workflows/models-lean-review.yml
+++ b/.github/workflows/models-lean-review.yml
@@ -15,7 +15,7 @@ jobs:
   get-diff:
     runs-on: ubuntu-latest
       outputs:
-            skip: "${{ steps.diff.outputs.skip }}"
+                  skip: "${{ steps.diff.outputs.skip }}"
       steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Fix outputs.skip indentation (was 12 spaces, should be 6) causing YAML parse error on line 17