### PR TITLE
fix: isolate legacy ByteWire toy model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@
 Источник истины по границе claims — `rubin-formal/proof_coverage.json` (`proof_level`, `claims`).
 Дополнительно используется `claim_level` (`toy|byte|refined`) с CI-валидацией консистентности относительно `proof_level`.
 
+Важно по wire-моделям:
+
+- `RubinFormal.ByteWireV2` — реальная CompactSize / byte-accurate proof surface для текущих wire claims.
+- `RubinFormal.ByteWire` — deprecated shim без собственных wire-лемм.
+- `RubinFormal.ByteWireLegacy` — toy bootstrap-модель только для single-byte `CompactSize` (`n < 253`) и `TxMini`.
+
 ## Risk model / CI gate
 
 - Док: `rubin-formal/RISK_MODEL.md`

--- a/RubinFormal/ByteWire.lean
+++ b/RubinFormal/ByteWire.lean
@@ -1,76 +1,13 @@
-import Std
+import RubinFormal.ByteWireLegacy
 
-namespace RubinFormal
+/-
+Deprecated compatibility shim.
 
-abbrev Byte := Nat
+`RubinFormal.ByteWire` no longer carries the legacy toy `CompactSize` model directly,
+because the old unqualified names were easy to confuse with the real proof surface.
 
-def encodeCompactSize (n : Nat) : List Byte :=
-  if h : n < 253 then
-    [n]
-  else
-    []
-
-def parseCompactSize : List Byte -> Option (Nat × List Byte)
-  | [] => none
-  | b :: rest =>
-      if b < 256 then
-        if b < 253 then
-          some (b, rest)
-        else
-          none
-      else
-        none
-
-theorem parse_encodeCompactSize_roundtrip (n : Nat) (h : n < 253) :
-    parseCompactSize (encodeCompactSize n) = some (n, []) := by
-  have h256 : n < 256 := Nat.lt_trans h (by decide)
-  simp [encodeCompactSize, parseCompactSize, h, h256]
-
-theorem encodeCompactSize_single_byte_unique
-    (n m : Nat) (hn : n < 253) (hm : m < 253)
-    (hEq : encodeCompactSize n = encodeCompactSize m) :
-    n = m := by
-  simpa [encodeCompactSize, hn, hm] using hEq
-
-structure TxMini where
-  version : Byte
-  txKind : Byte
-  txNonce : Byte
-deriving DecidableEq
-
-def txMiniByteValid (tx : TxMini) : Prop :=
-  tx.version < 256 ∧ tx.txKind < 256 ∧ tx.txNonce < 256
-
-def serializeTxMini (tx : TxMini) : List Byte :=
-  [tx.version, tx.txKind, tx.txNonce]
-
-def parseTxMini : List Byte -> Option TxMini
-  | [version, txKind, txNonce] =>
-      if h1 : version < 256 then
-        if h2 : txKind < 256 then
-          if h3 : txNonce < 256 then
-            some { version, txKind, txNonce }
-          else
-            none
-        else
-          none
-      else
-            none
-  | _ => none
-
-theorem parse_serializeTxMini_roundtrip (tx : TxMini) (h : txMiniByteValid tx) :
-    parseTxMini (serializeTxMini tx) = some tx := by
-  cases tx
-  simp [txMiniByteValid] at h
-  rcases h with ⟨h1, h2, h3⟩
-  simp [serializeTxMini, parseTxMini, h1, h2, h3]
-
-theorem parseTxMini_deterministic (bs : List Byte) (a b : TxMini)
-    (ha : parseTxMini bs = some a)
-    (hb : parseTxMini bs = some b) :
-    a = b := by
-  rw [ha] at hb
-  cases hb
-  rfl
-
-end RubinFormal
+- Use `RubinFormal.ByteWireV2` for the byte-accurate parser/CompactSize theorems that
+  back current wire claims.
+- Use `RubinFormal.ByteWireLegacy` only when a proof explicitly needs the toy
+  bootstrap model restricted to the single-byte `CompactSize` case.
+-/

--- a/RubinFormal/ByteWireLegacy.lean
+++ b/RubinFormal/ByteWireLegacy.lean
@@ -1,0 +1,88 @@
+import Std
+
+/-
+Legacy bootstrap-only byte model.
+
+This file intentionally models only the single-byte `CompactSize` case (`n < 253`)
+plus a tiny three-byte transaction record used in early toy lemmas. It is not the
+real RUBIN wire proof surface. Use `RubinFormal.ByteWireV2` for the byte-accurate
+CompactSize/parser model referenced by the coverage registry.
+-/
+namespace RubinFormal
+
+namespace ByteWireLegacy
+
+abbrev Byte := Nat
+
+def encodeCompactSizeToy (n : Nat) : List Byte :=
+  if n < 253 then
+    [n]
+  else
+    []
+
+def parseCompactSizeToy : List Byte -> Option (Nat × List Byte)
+  | [] => none
+  | b :: rest =>
+      if b < 256 then
+        if b < 253 then
+          some (b, rest)
+        else
+          none
+      else
+        none
+
+theorem parse_encodeCompactSizeToy_roundtrip (n : Nat) (h : n < 253) :
+    parseCompactSizeToy (encodeCompactSizeToy n) = some (n, []) := by
+  have h256 : n < 256 := Nat.lt_trans h (by decide)
+  simp [encodeCompactSizeToy, parseCompactSizeToy, h, h256]
+
+theorem encodeCompactSizeToy_single_byte_unique
+    (n m : Nat) (hn : n < 253) (hm : m < 253)
+    (hEq : encodeCompactSizeToy n = encodeCompactSizeToy m) :
+    n = m := by
+  simpa [encodeCompactSizeToy, hn, hm] using hEq
+
+structure TxMini where
+  version : Byte
+  txKind : Byte
+  txNonce : Byte
+deriving DecidableEq
+
+def txMiniByteValid (tx : TxMini) : Prop :=
+  tx.version < 256 ∧ tx.txKind < 256 ∧ tx.txNonce < 256
+
+def serializeTxMini (tx : TxMini) : List Byte :=
+  [tx.version, tx.txKind, tx.txNonce]
+
+def parseTxMini : List Byte -> Option TxMini
+  | [version, txKind, txNonce] =>
+      if version < 256 then
+        if txKind < 256 then
+          if txNonce < 256 then
+            some { version, txKind, txNonce }
+          else
+            none
+        else
+          none
+      else
+        none
+  | _ => none
+
+theorem parse_serializeTxMini_roundtrip (tx : TxMini) (h : txMiniByteValid tx) :
+    parseTxMini (serializeTxMini tx) = some tx := by
+  cases tx
+  simp [txMiniByteValid] at h
+  rcases h with ⟨h1, h2, h3⟩
+  simp [serializeTxMini, parseTxMini, h1, h2, h3]
+
+theorem parseTxMini_deterministic (bs : List Byte) (a b : TxMini)
+    (ha : parseTxMini bs = some a)
+    (hb : parseTxMini bs = some b) :
+    a = b := by
+  rw [ha] at hb
+  cases hb
+  rfl
+
+end ByteWireLegacy
+
+end RubinFormal

--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -1,4 +1,5 @@
-import RubinFormal.ByteWire
+import RubinFormal.ByteWireLegacy
+import RubinFormal.ByteWireV2
 import RubinFormal.ArithmeticSafety
 import RubinFormal.Conformance.Index
 import RubinFormal.PinnedSections

--- a/RubinFormal/PinnedSections.lean
+++ b/RubinFormal/PinnedSections.lean
@@ -1,5 +1,5 @@
 import RubinFormal.CriticalInvariants
-import RubinFormal.ByteWire
+import RubinFormal.ByteWireLegacy
 import RubinFormal.ArithmeticSafety
 import RubinFormal.CoreExtInvariants
 import RubinFormal.SighashV1
@@ -7,10 +7,16 @@ import RubinFormal.CovenantGenesisV1
 
 namespace RubinFormal
 
+/-- Bootstrap-only transaction-wire statement.
+    The `CompactSize` and `TxMini` conjuncts intentionally use the legacy toy model in
+    `ByteWireLegacy`; byte-accurate wire claims come from `ByteWireV2` and conformance replay,
+    as tracked in `proof_coverage.json`. -/
 def transactionWireStatement : Prop :=
   parseTransactionWire [] = none ∧
-  (∀ n : Nat, n < 253 → parseCompactSize (encodeCompactSize n) = some (n, [])) ∧
-  (∀ tx : TxMini, txMiniByteValid tx → parseTxMini (serializeTxMini tx) = some tx)
+  (∀ n : Nat, n < 253 →
+    ByteWireLegacy.parseCompactSizeToy (ByteWireLegacy.encodeCompactSizeToy n) = some (n, [])) ∧
+  (∀ tx : ByteWireLegacy.TxMini, ByteWireLegacy.txMiniByteValid tx →
+    ByteWireLegacy.parseTxMini (ByteWireLegacy.serializeTxMini tx) = some tx)
 /-- v2 (F-01 fix): ByteArray preimage distinctness for txid ≠ wtxid.
     When witness is non-empty (coreEnd < tx.size), the txid preimage
     (tx.extract 0 coreEnd) differs from the wtxid preimage (full tx). -/
@@ -109,9 +115,9 @@ theorem transaction_wire_proved : transactionWireStatement := by
   refine ⟨?_, ?_, ?_⟩
   · simpa using parse_empty_none
   · intro n hn
-    exact parse_encodeCompactSize_roundtrip n hn
+    exact ByteWireLegacy.parse_encodeCompactSizeToy_roundtrip n hn
   · intro tx htx
-    exact parse_serializeTxMini_roundtrip tx htx
+    exact ByteWireLegacy.parse_serializeTxMini_roundtrip tx htx
 
 theorem transaction_identifiers_proved : transactionIdentifiersStatement := by
   intro tx coreEnd h

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -44,7 +44,7 @@
         "RubinFormal.Wire.compactSize_overflow_safety": "rubin-formal/RubinFormal/ByteWireV2.lean"
       },
       "limitations": [
-        "The legacy toy model in ByteWire.lean is not treated as a universal wire proof.",
+        "The deprecated shim ByteWire.lean is not a proof surface; the toy bootstrap model lives in ByteWireLegacy.lean.",
         "Byte-accurate claim is limited to the listed replay and ByteWireV2 theorems."
       ]
     },


### PR DESCRIPTION
## Summary
- move the old single-byte CompactSize toy model into `RubinFormal.ByteWireLegacy`
- turn `RubinFormal.ByteWire` into a deprecated compatibility shim with explicit scope markers
- retarget `PinnedSections`, `Index`, `README.md`, and `proof_coverage.json` so the real wire proof surface stays clearly anchored on `ByteWireV2`

## Validation
- `lake build`
- `rg -n "\\bsorry\\b" RubinFormal`

## Context
- Q-FORMAL-BYTEWIRE-HYGIENE-01
- Baseline: `rubin-formal@377a2b58c9bc8834c0e84d926add39742efbf197`
- Scope: formal hygiene only; no runtime or consensus semantics change
