### PR TITLE
fix: add explicit merkle termination surface

### DIFF
--- a/RubinFormal/MerkleStructure.lean
+++ b/RubinFormal/MerkleStructure.lean
@@ -44,6 +44,10 @@ theorem reduceLevel_length_lt (xs : List Bytes) (h : 2 ≤ xs.length) :
           simp [reduceLevel]
           omega
 
+theorem merkleRoot_termination_measure (level : List Bytes) (h : 2 ≤ level.length) :
+    (reduceLevel level).length < level.length := by
+  exact reduceLevel_length_lt level h
+
 theorem leafTag_ne_nodeTag : (0x00 : UInt8) ≠ 0x01 := by
   decide
 

--- a/RubinFormal/MerkleV2.lean
+++ b/RubinFormal/MerkleV2.lean
@@ -1,3 +1,4 @@
+import Std
 import RubinFormal.Types
 import RubinFormal.SHA3_256
 
@@ -17,19 +18,46 @@ def reduceLevel (xs : List Bytes) : List Bytes :=
   | [x] => [x]
   | x :: y :: rest => nodeHash x y :: reduceLevel rest
 
-def merkleRoot (txids : List Bytes) : Option Bytes :=
-  match txids with
+private theorem reduceLevel_length_le_internal (xs : List Bytes) :
+    (reduceLevel xs).length ≤ xs.length := by
+  cases xs with
+  | nil =>
+      simp [reduceLevel]
+  | cons x xs =>
+      cases xs with
+      | nil =>
+          simp [reduceLevel]
+      | cons y rest =>
+          have hLe : (reduceLevel rest).length ≤ rest.length := reduceLevel_length_le_internal rest
+          simp [reduceLevel]
+          omega
+
+private theorem reduceLevel_length_lt_internal (xs : List Bytes) (h : 2 ≤ xs.length) :
+    (reduceLevel xs).length < xs.length := by
+  cases xs with
+  | nil =>
+      simp at h
+  | cons x xs =>
+      cases xs with
+      | nil =>
+          simp at h
+      | cons y rest =>
+          have hLe : (reduceLevel rest).length ≤ rest.length := reduceLevel_length_le_internal rest
+          simp [reduceLevel]
+          omega
+
+def merkleRootFromLevel : List Bytes → Option Bytes
   | [] => none
-  | _ =>
-      let rec go (fuel : Nat) (level : List Bytes) : Option Bytes :=
-        match fuel with
-        | 0 => none
-        | fuel + 1 =>
-            match level with
-            | [] => none
-            | [r] => some r
-            | _ => go fuel (reduceLevel level)
-      go txids.length (txids.map leafHash)
+  | [r] => some r
+  | x :: y :: rest => merkleRootFromLevel (reduceLevel (x :: y :: rest))
+termination_by level => level.length
+decreasing_by
+  simpa using
+    reduceLevel_length_lt_internal (x :: y :: rest)
+      (Nat.succ_le_succ (Nat.succ_le_succ (Nat.zero_le _)))
+
+def merkleRoot (txids : List Bytes) : Option Bytes :=
+  merkleRootFromLevel (txids.map leafHash)
 
 end Merkle
 end RubinFormal


### PR DESCRIPTION
## Summary
- Replace fuel-based merkle helper with structural recursion using termination_by level.length
- Add theorem merkleRoot_termination_measure in MerkleStructure.lean

## QID
Q-FORMAL-DESIGN-MERKLE-01

## Test plan
- `lake build` passes in clean worktree
- 0 sorry