### PR TITLE
fix: expose coinbase maturity core theorem

### DIFF
--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -315,6 +315,32 @@ def InputScanState.empty : InputScanState :=
     consumedOutpoints := []
   }
 
+def validateCoinbaseMaturity
+    (e : UtxoEntry)
+    (height : Nat) : Except String Unit :=
+  if e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY then
+    .error "TX_ERR_COINBASE_IMMATURE"
+  else
+    .ok ()
+
+theorem validateCoinbaseMaturity_reject_iff
+    (e : UtxoEntry)
+    (height : Nat) :
+    validateCoinbaseMaturity e height = .error "TX_ERR_COINBASE_IMMATURE" ↔
+      e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY := by
+  by_cases hReject : e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY
+  · simp [validateCoinbaseMaturity, hReject]
+  · simp [validateCoinbaseMaturity, hReject]
+
+theorem validateCoinbaseMaturity_accept_iff
+    (e : UtxoEntry)
+    (height : Nat) :
+    validateCoinbaseMaturity e height = .ok () ↔
+      ¬(e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY) := by
+  by_cases hReject : e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY
+  · simp [validateCoinbaseMaturity, hReject]
+  · simp [validateCoinbaseMaturity, hReject]
+
 structure PreparedNonCoinbaseTx where
   tx : Tx
   inputState : InputScanState
@@ -347,9 +373,7 @@ def scanSingleInputStep
   if e.covenantType == COV_TYPE_ANCHOR || e.covenantType == COV_TYPE_DA_COMMIT then
     throw "TX_ERR_MISSING_UTXO"
 
-  if e.createdByCoinbase then
-    if height < e.creationHeight + COINBASE_MATURITY then
-      throw "TX_ERR_COINBASE_IMMATURE"
+  validateCoinbaseMaturity e height
 
   if e.covenantType == COV_TYPE_P2PK then
     if e.covenantData.size != MAX_P2PK_COVENANT_DATA then

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -162,6 +162,7 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
+        "RubinFormal.UtxoBasicV1.validateCoinbaseMaturity_reject_iff",
         "RubinFormal.det001_validation_order_proved",
         "RubinFormal.Conformance.vault_policy_default_order_safe_proved",
         "RubinFormal.UtxoApplyGenesisV1.creation_owner_auth_p2pk_or_multisig",
@@ -180,6 +181,7 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
+        "RubinFormal.UtxoBasicV1.validateCoinbaseMaturity_reject_iff": "rubin-formal/RubinFormal/UtxoBasicV1.lean",
         "RubinFormal.Conformance.vault_policy_default_order_safe_proved": "rubin-formal/RubinFormal/Conformance/CVVaultPolicyReplay.lean",
         "RubinFormal.UtxoApplyGenesisV1.creation_owner_auth_p2pk_or_multisig": "rubin-formal/RubinFormal/UtxoApplyGenesisV1.lean",
         "RubinFormal.UtxoApplyGenesisV1.output_whitelist_closure": "rubin-formal/RubinFormal/UtxoApplyGenesisV1.lean",
@@ -195,7 +197,7 @@
         "RubinFormal.Conformance.vault_full_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
         "RubinFormal.Conformance.vault_cancel_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean"
       },
-      "notes": "Section claim is limited to structural UTXO/value invariants, concrete tx-level vault predicate witnesses, sequential connectBlock composition, and executable replay for the covered vault/vector families.",
+      "notes": "Section claim is limited to structural UTXO/value invariants, a direct immature-coinbase reject boundary theorem, concrete tx-level vault predicate witnesses, sequential connectBlock composition, and executable replay for the covered vault/vector families.",
       "limitations": [
         "vault_policy_default_order_safe_proved remains the spend-side safe-subset theorem for CV-VAULT-POLICY; the added tx-level witnesses do not claim universal L1↔L2 equivalence for all vault transactions."
       ]


### PR DESCRIPTION
## Summary
- Add formal coinbase maturity enforcement theorem in UtxoBasicV1
- Prove that coinbase outputs cannot be spent before maturity period

## QID
Q-FORMAL-COINBASE-MATURITY-CORE-01

## Test plan
- `lake build` passes in clean worktree
- 0 sorry