### PR TITLE
fix: expose coinbase maturity core theorem

### DIFF
--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -315,6 +315,32 @@ def InputScanState.empty : InputScanState :=
     consumedOutpoints := []
   }
 
+def validateCoinbaseMaturity
+    (e : UtxoEntry)
+    (height : Nat) : Except String Unit :=
+  if e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY then
+    .error "TX_ERR_COINBASE_IMMATURE"
+  else
+    .ok ()
+
+theorem validateCoinbaseMaturity_reject_iff
+    (e : UtxoEntry)
+    (height : Nat) :
+    validateCoinbaseMaturity e height = .error "TX_ERR_COINBASE_IMMATURE" ↔
+      e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY := by
+  by_cases hReject : e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY
+  · simp [validateCoinbaseMaturity, hReject]
+  · simp [validateCoinbaseMaturity, hReject]
+
+theorem validateCoinbaseMaturity_accept_iff
+    (e : UtxoEntry)
+    (height : Nat) :
+    validateCoinbaseMaturity e height = .ok () ↔
+      ¬(e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY) := by
+  by_cases hReject : e.createdByCoinbase = true ∧ height < e.creationHeight + COINBASE_MATURITY
+  · simp [validateCoinbaseMaturity, hReject]
+  · simp [validateCoinbaseMaturity, hReject]
+
 structure PreparedNonCoinbaseTx where
   tx : Tx
   inputState : InputScanState
@@ -347,9 +373,7 @@ def scanSingleInputStep
   if e.covenantType == COV_TYPE_ANCHOR || e.covenantType == COV_TYPE_DA_COMMIT then
     throw "TX_ERR_MISSING_UTXO"
 
-  if e.createdByCoinbase then
-    if height < e.creationHeight + COINBASE_MATURITY then
-      throw "TX_ERR_COINBASE_IMMATURE"
+  validateCoinbaseMaturity e height
 
   if e.covenantType == COV_TYPE_P2PK then
     if e.covenantData.size != MAX_P2PK_COVENANT_DATA then

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -161,6 +161,7 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",
+        "RubinFormal.UtxoBasicV1.validateCoinbaseMaturity_reject_iff",
         "RubinFormal.det001_validation_order_proved",
         "RubinFormal.Conformance.vault_policy_default_order_safe_proved",
         "RubinFormal.triggered_implies_sweepable",
@@ -174,6 +175,7 @@
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
+        "RubinFormal.UtxoBasicV1.validateCoinbaseMaturity_reject_iff": "rubin-formal/RubinFormal/UtxoBasicV1.lean",
         "RubinFormal.Conformance.vault_policy_default_order_safe_proved": "rubin-formal/RubinFormal/Conformance/CVVaultPolicyReplay.lean",
         "RubinFormal.triggered_implies_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
         "RubinFormal.cancelled_implies_not_sweepable": "rubin-formal/RubinFormal/VaultStateMachine.lean",
@@ -184,7 +186,7 @@
         "RubinFormal.Conformance.vault_full_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean",
         "RubinFormal.Conformance.vault_cancel_lifecycle_valid": "rubin-formal/RubinFormal/Conformance/CVVaultLifecycleReplay.lean"
       },
-      "notes": "Section claim is limited to structural UTXO/value invariants, sequential connectBlock composition, and executable replay for the covered vault/vector families.",
+      "notes": "Section claim is limited to structural UTXO/value invariants, a direct immature-coinbase reject boundary theorem, sequential connectBlock composition, and executable replay for the covered vault/vector families.",
       "limitations": [
         "vault_policy_default_order_safe_proved models only the spend-side safe subset for CV-VAULT-POLICY.",
         "Uncovered tx-level predicates remain: creation_owner_auth_p2pk_or_multisig, output_whitelist_closure, vault_recursion_ban, parse_vault_canonical_invariants, owner_destination_forbidden."


### PR DESCRIPTION
Q-FORMAL-COINBASE-MATURITY-CORE-01

## Summary
- factor coinbase maturity enforcement into a standalone `validateCoinbaseMaturity` helper
- prove direct reject/accept iff theorems for the immature coinbase boundary
- record the standalone theorem in `proof_coverage.json` so the claimed proof surface matches the new core theorem

## Validation
- `lake build`
- no `sorry` occurrences in repo scan
- spec hash check: `git show origin/main:spec/RUBIN_L1_CANONICAL.md | shasum -a 256` matched `879df7749f1399117cd71e5635e1a5ca17c5a8999e3a0033694fe6733cb45390`

## Notes
- canonical queue task narrowed this work to a standalone proof-surface theorem / coverage update, not a runtime semantics change
- local current-origin validation was repeated against `origin/main@0f4d8689b9801255e3f48be482b6b840ff35c218`