### PR TITLE
formal: prove timestamp bound acceptance

### DIFF
--- a/RubinFormal/BlockBasicCheckV1.lean
+++ b/RubinFormal/BlockBasicCheckV1.lean
@@ -34,12 +34,52 @@ def medianTimePast (prevTimestamps : List Nat) : Except String Nat := do
   let sorted := sortNat prevTimestamps
   pure (sorted.get! (sorted.length / 2))
 
-def timestampBounds (mtp ts : Nat) : Except String Unit := do
+def timestampBounds (mtp ts : Nat) : Except String Unit :=
   if ts <= mtp then
-    throw "BLOCK_ERR_TIMESTAMP_OLD"
-  if ts > mtp + MAX_FUTURE_DRIFT then
-    throw "BLOCK_ERR_TIMESTAMP_FUTURE"
-  pure ()
+    .error "BLOCK_ERR_TIMESTAMP_OLD"
+  else if ts > mtp + MAX_FUTURE_DRIFT then
+    .error "BLOCK_ERR_TIMESTAMP_FUTURE"
+  else
+    .ok ()
+
+theorem timestampBounds_ok_iff (mtp ts : Nat) :
+    timestampBounds mtp ts = .ok () ↔ mtp < ts ∧ ts ≤ mtp + MAX_FUTURE_DRIFT := by
+  unfold timestampBounds
+  by_cases hOld : ts ≤ mtp
+  · have hNotGt : ¬ mtp < ts := Nat.not_lt_of_ge hOld
+    simp [hOld, hNotGt]
+  · have hGt : mtp < ts := Nat.lt_of_not_ge hOld
+    by_cases hFuture : ts > mtp + MAX_FUTURE_DRIFT
+    · have hNotLe : ¬ ts ≤ mtp + MAX_FUTURE_DRIFT := Nat.not_le_of_gt hFuture
+      simp [hOld, hFuture, hGt, hNotLe]
+    · have hLe : ts ≤ mtp + MAX_FUTURE_DRIFT := Nat.le_of_not_gt hFuture
+      simp [hOld, hFuture, hGt, hLe]
+
+theorem timestampBounds_old_iff (mtp ts : Nat) :
+    timestampBounds mtp ts = .error "BLOCK_ERR_TIMESTAMP_OLD" ↔ ts ≤ mtp := by
+  unfold timestampBounds
+  by_cases hOld : ts ≤ mtp
+  · simp [hOld]
+  · have hGt : mtp < ts := Nat.lt_of_not_ge hOld
+    by_cases hFuture : ts > mtp + MAX_FUTURE_DRIFT
+    · have hErrNe : ("BLOCK_ERR_TIMESTAMP_FUTURE" : String) ≠ "BLOCK_ERR_TIMESTAMP_OLD" := by
+        decide
+      simp [hOld, hFuture, hGt, hErrNe]
+    · simp [hOld, hFuture, hGt]
+
+theorem timestampBounds_future_iff (mtp ts : Nat) :
+    timestampBounds mtp ts = .error "BLOCK_ERR_TIMESTAMP_FUTURE" ↔ mtp < ts ∧ mtp + MAX_FUTURE_DRIFT < ts := by
+  unfold timestampBounds
+  by_cases hOld : ts ≤ mtp
+  · have hNotGt : ¬ mtp < ts := Nat.not_lt_of_ge hOld
+    have hErrNe : ("BLOCK_ERR_TIMESTAMP_OLD" : String) ≠ "BLOCK_ERR_TIMESTAMP_FUTURE" := by
+      decide
+    simp [hOld, hNotGt, hErrNe]
+  · have hGt : mtp < ts := Nat.lt_of_not_ge hOld
+    by_cases hFuture : ts > mtp + MAX_FUTURE_DRIFT
+    · simp [hOld, hFuture, hGt]
+    · have hNotFuture : ¬ mtp + MAX_FUTURE_DRIFT < ts := hFuture
+      simp [hOld, hFuture, hGt, hNotFuture]
 
 def txNonceFromTxBytes (tx : Bytes) : Except String Nat := do
   let c0 : Cursor := { bs := tx, off := 0 }

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -242,14 +242,21 @@
     {
       "section_key": "block_timestamp_rules",
       "section_heading": "## 22. Block Timestamp Rules (Normative)",
-      "status": "stated",
+      "status": "proved",
       "theorems": [
-        "RubinFormal.Conformance.cv_timestamp_vectors_pass"
+        "RubinFormal.Conformance.cv_timestamp_vectors_pass",
+        "RubinFormal.BlockBasicCheckV1.timestampBounds_ok_iff",
+        "RubinFormal.BlockBasicCheckV1.timestampBounds_old_iff",
+        "RubinFormal.BlockBasicCheckV1.timestampBounds_future_iff"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "notes": "Current entry is executable replay for timestamp-bounds and block-basic timestamp validation vectors.",
+      "file": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
+      "theorem_files": {
+        "RubinFormal.Conformance.cv_timestamp_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVTimestampReplay.lean"
+      },
+      "notes": "Current entry combines executable replay for timestamp-bounds and block-basic timestamp vectors with universal theorems for the old/future accept-reject boundary of `timestampBounds` once median-time-past has been supplied.",
       "limitations": [
-        "No standalone universal theorem for every timestamp-rule case is claimed beyond conformance replay."
+        "The universal theorem layer is over `timestampBounds` given an already-derived median-time-past value; the list-to-MTP extraction path remains evidenced by executable replay rather than a standalone theorem.",
+        "No chain-wide timestamp monotonicity claim beyond the covered `timestampBounds` gate and current replayed integration path is asserted here."
       ]
     },
     {


### PR DESCRIPTION
Q-ID: Q-FORMAL-MTP-THEOREM-01

## Summary
- add universal `timestampBounds` theorems for ok/old/future branches
- tighten `proof_coverage.json` so `block_timestamp_rules` is theorem-backed instead of replay-only

## Validation
- `PATH="$HOME/.elan/bin:$PATH" lake build`

Source: reports/2026-03-12_report_validated_audit_nonfalse_local_intake.md