### PR TITLE
formal: add sighash preimage injectivity boundary theorem

### DIFF
--- a/RubinFormal/SighashV1.lean
+++ b/RubinFormal/SighashV1.lean
@@ -145,6 +145,70 @@ def hashOfDA (txKind : UInt8) : Bytes :=
     -- Not needed for current CV-SIGHASH vectors.
     SHA3.sha3_256 ByteArray.empty
 
+structure SighashPreimageFrame where
+  chainId : Bytes
+  versionLE : Bytes
+  txKind : UInt8
+  txNonceLE : Bytes
+  hashDA : Bytes
+  hashPrevouts : Bytes
+  hashSeq : Bytes
+  inputIndexLE : Bytes
+  prevTxid : Bytes
+  prevVoutLE : Bytes
+  inputValueLE : Bytes
+  sequenceLE : Bytes
+  hashOutputs : Bytes
+  locktimeLE : Bytes
+deriving Repr, DecidableEq
+
+def SighashPreimageFrame.WellFormed (f : SighashPreimageFrame) : Prop :=
+  f.chainId.size = 32 ∧
+  f.versionLE.size = 4 ∧
+  f.txNonceLE.size = 8 ∧
+  f.hashDA.size = 32 ∧
+  f.hashPrevouts.size = 32 ∧
+  f.hashSeq.size = 32 ∧
+  f.inputIndexLE.size = 4 ∧
+  f.prevTxid.size = 32 ∧
+  f.prevVoutLE.size = 4 ∧
+  f.inputValueLE.size = 8 ∧
+  f.sequenceLE.size = 4 ∧
+  f.hashOutputs.size = 32 ∧
+  f.locktimeLE.size = 4
+
+def buildPreimageFrameParts (f : SighashPreimageFrame) : List Bytes :=
+  [
+    sighashPrefix,
+    f.chainId,
+    f.versionLE,
+    RubinFormal.bytes #[f.txKind],
+    f.txNonceLE,
+    f.hashDA,
+    f.hashPrevouts,
+    f.hashSeq,
+    f.inputIndexLE,
+    f.prevTxid,
+    f.prevVoutLE,
+    f.inputValueLE,
+    f.sequenceLE,
+    f.hashOutputs,
+    f.locktimeLE
+  ]
+
+def buildPreimageFrame (f : SighashPreimageFrame) : Bytes :=
+  concatBytes (buildPreimageFrameParts f)
+
+theorem buildPreimageFrameParts_injective (a b : SighashPreimageFrame)
+    (hEq : buildPreimageFrameParts a = buildPreimageFrameParts b) :
+    a = b := by
+  cases a with
+  | mk aChainId aVersionLE aTxKind aTxNonceLE aHashDA aHashPrevouts aHashSeq aInputIndexLE aPrevTxid aPrevVoutLE aInputValueLE aSequenceLE aHashOutputs aLocktimeLE =>
+    cases b with
+    | mk bChainId bVersionLE bTxKind bTxNonceLE bHashDA bHashPrevouts bHashSeq bInputIndexLE bPrevTxid bPrevVoutLE bInputValueLE bSequenceLE bHashOutputs bLocktimeLE =>
+      simp [buildPreimageFrameParts, RubinFormal.bytes] at hEq ⊢
+      simpa using hEq
+
 def digestV1 (tx : Bytes) (chainId : Bytes) (inputIndex : Nat) (inputValue : Nat) : Except String Bytes := do
   let core ← parseTxCoreForSighash tx
   let inCount := core.inputs.length

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -86,20 +86,22 @@
       "section_heading": "## 12. Sighash v1 (Normative)",
       "status": "stated",
       "theorems": [
-        "RubinFormal.Conformance.cv_sighash_vectors_pass",
-        "RubinFormal.digestV1_deterministic"
-      ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "theorem_files": {
-        "RubinFormal.digestV1_deterministic": "rubin-formal/RubinFormal/SighashV1.lean"
-      },
-      "notes": "Claim is limited to executable replay on the conformance fixture set plus determinism of digestV1; structural pre-hash injectivity is intentionally outside the claimed proof surface for this entry.",
-      "limitations": [
-        "The bootstrap size-invariant theorem in PinnedSections is not treated as a full sighash correctness proof.",
-        "No universal equivalence proof for every §12 case beyond conformance replay is claimed.",
-        "No standalone theorem is claimed that different signing contexts necessarily produce distinct pre-hash sighash preimage bytes before SHA3-256."
-      ]
+      "RubinFormal.Conformance.cv_sighash_vectors_pass",
+      "RubinFormal.digestV1_deterministic",
+      "RubinFormal.SighashV1.buildPreimageFrameParts_injective"
+    ],
+    "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+    "theorem_files": {
+      "RubinFormal.digestV1_deterministic": "rubin-formal/RubinFormal/SighashV1.lean",
+      "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean"
     },
+    "notes": "Claim is limited to executable replay on the conformance fixture set plus determinism of digestV1 and a standalone injectivity theorem for the segmented fixed-width preimage frame builder before final byte concatenation and the final SHA3-256 call.",
+    "limitations": [
+      "The bootstrap size-invariant theorem in PinnedSections is not treated as a full sighash correctness proof.",
+      "No universal equivalence proof for every §12 case beyond conformance replay is claimed.",
+      "The injectivity theorem is over the segmented fixed-width preimage frame builder after field-by-field byte encoding, not over arbitrary raw transactions, fully concatenated preimage bytes, or cryptographic collision resistance."
+    ]
+  },
     {
       "section_key": "consensus_error_codes",
       "section_heading": "## 13. Consensus Error Codes (Normative)",


### PR DESCRIPTION
Q-FORMAL-SIGHASH-PREIMAGE-INJECTIVITY-01

## Summary
- add a standalone injectivity theorem for the segmented fixed-width sighash preimage frame builder in `RubinFormal/SighashV1.lean`
- keep the claim honest in `proof_coverage.json`: the theorem covers segmented preimage-frame structure before final byte concatenation and SHA3, not arbitrary raw txs or crypto collision resistance
- leave consensus/spec semantics unchanged

## Validation
- `PATH="$HOME/.elan/bin:$PATH" && lake build`