### PR TITLE
feat: standalone witness-commitment theorem surface

### DIFF
--- a/RubinFormal/BlockBasicV1.lean
+++ b/RubinFormal/BlockBasicV1.lean
@@ -19,6 +19,9 @@ def witnessPrefix : Bytes :=
     0x52,0x55,0x42,0x49,0x4e,0x2d,0x57,0x49,0x54,0x4e,0x45,0x53,0x53,0x2f
   ]
 
+def coinbaseWitnessReservedValue : Bytes :=
+  RubinFormal.bytes ((List.replicate 32 (UInt8.ofNat 0)).toArray)
+
 structure BlockHeader where
   version : Nat
   prevHash : Bytes
@@ -223,8 +226,7 @@ def witnessMerkleRootWtxids (wtxids : List Bytes) : Except String Bytes := do
   if wtxids.isEmpty then throw "BLOCK_ERR_PARSE"
   let mut ids := wtxids
   -- coinbase slot commits as zero bytes (CANONICAL §10.4.1)
-  let zero32 : Bytes := RubinFormal.bytes ((List.replicate 32 (UInt8.ofNat 0)).toArray)
-  ids := zero32 :: (ids.drop 1)
+  ids := coinbaseWitnessReservedValue :: (ids.drop 1)
   merkleRootTagged ids 0x02 0x03
 
 def witnessCommitmentHash (witnessRoot : Bytes) : Bytes :=
@@ -261,6 +263,14 @@ def findCoinbaseAnchorCommitment (coinbaseTx : Bytes) : Except String Bytes := d
       throw "BLOCK_ERR_WITNESS_COMMITMENT"
     pure anchorData
 
+def checkWitnessCommitment (pb : ParsedBlock) : Except String Unit := do
+  let witnessRoot ← witnessMerkleRootWtxids pb.wtxids
+  let expectedCommit := witnessCommitmentHash witnessRoot
+  let gotCommit ← findCoinbaseAnchorCommitment pb.coinbaseTx
+  if gotCommit != expectedCommit then
+    throw "BLOCK_ERR_WITNESS_COMMITMENT"
+  pure ()
+
 def validateBlockBasic
     (blockHex : Bytes)
     (expectedPrevHash : Option Bytes)
@@ -284,12 +294,7 @@ def validateBlockBasic
   if mr != pb.header.merkleRoot then
     throw "BLOCK_ERR_MERKLE_INVALID"
   -- witness commitment check
-  let wmr ← witnessMerkleRootWtxids pb.wtxids
-  let expectCommit := witnessCommitmentHash wmr
-  let gotCommit ← findCoinbaseAnchorCommitment pb.coinbaseTx
-  if gotCommit != expectCommit then
-    throw "BLOCK_ERR_WITNESS_COMMITMENT"
-  pure ()
+  checkWitnessCommitment pb
 
 -- F-AUDIT-04: Duplicate txid uniqueness.
 -- Go enforces nonce uniqueness in validateBlockTxSemantics (block_basic_txs.go:35-39)

--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -12,6 +12,7 @@ import RubinFormal.TxWeightV2
 import RubinFormal.UtxoBasicV1
 import RubinFormal.VaultStateMachine
 import RubinFormal.BlockBasicV1
+import RubinFormal.WitnessCommitmentV1
 import RubinFormal.BlockBasicCheckV1
 import RubinFormal.MerkleStructure
 import RubinFormal.SubsidyV1

--- a/RubinFormal/PinnedSections.lean
+++ b/RubinFormal/PinnedSections.lean
@@ -4,6 +4,7 @@ import RubinFormal.ArithmeticSafety
 import RubinFormal.CoreExtInvariants
 import RubinFormal.SighashV1
 import RubinFormal.CovenantGenesisV1
+import RubinFormal.WitnessCommitmentV1
 
 namespace RubinFormal
 
@@ -25,10 +26,36 @@ def transactionIdentifiersStatement : Prop :=
     coreEnd < tx.size → tx.extract 0 coreEnd ≠ tx
 def weightAccountingStatement : Prop :=
   ∀ base witness1 witness2 sigCost : Nat, witness1 ≤ witness2 → weight base witness1 sigCost ≤ weight base witness2 sigCost
-/-- v2 (F-03 fix): genesis height produces zero subsidy regardless of prior
-    accumulation. References real `SubsidyV1.blockSubsidy`. -/
+/-- v3 (D08-F02 fix): standalone witness-commitment semantics.
+    (1) Witness merkle construction zeroes the coinbase slot.
+    (2) The isolated witness-commitment step accepts iff the coinbase anchor
+        matches the prefixed witness-merkle commitment.
+    (3) Once parse/pow/target/linkage/merkle gates pass, `validateBlockBasic`
+        reduces exactly to this witness-commitment step. -/
 def witnessCommitmentStatement : Prop :=
-  ∀ (ag : Nat), SubsidyV1.blockSubsidy 0 ag = 0
+  (∀ (coinbaseWtxid : Bytes) (rest : List Bytes),
+    BlockBasicV1.witnessMerkleRootWtxids (coinbaseWtxid :: rest) =
+      BlockBasicV1.merkleRootTagged
+        (BlockBasicV1.coinbaseWitnessReservedValue :: rest) 0x02 0x03) ∧
+  (∀ (pb : BlockBasicV1.ParsedBlock) (witnessRoot gotCommit : Bytes),
+    BlockBasicV1.witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot →
+    BlockBasicV1.findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit →
+    (BlockBasicV1.checkWitnessCommitment pb = .ok () ↔
+      gotCommit = BlockBasicV1.witnessCommitmentHash witnessRoot)) ∧
+  (∀ (blockBytes : Bytes)
+      (expectedPrevHash expectedTarget : Option Bytes)
+      (pb : BlockBasicV1.ParsedBlock),
+    BlockBasicV1.parseBlock blockBytes = .ok pb →
+    BlockBasicV1.powCheck pb.header = .ok () →
+    (match expectedTarget with
+    | none => True
+    | some exp => pb.header.target = exp) →
+    (match expectedPrevHash with
+    | none => True
+    | some exp => pb.header.prevHash = exp) →
+    BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot →
+    BlockBasicV1.validateBlockBasic blockBytes expectedPrevHash expectedTarget =
+      BlockBasicV1.checkWitnessCommitment pb)
 /-- v2 (F-02 fix): sighash encoding size invariants over real `SighashV1.u64le`/`u32le`.
     Fixed encoding sizes (8 and 4 bytes) are essential for preimage domain separation
     in the sighash construction (`digestV1`). -/
@@ -128,8 +155,15 @@ theorem weight_accounting_proved : weightAccountingStatement := by
   exact weight_monotone_witness base witness1 witness2 sigCost hw
 
 theorem witness_commitment_proved : witnessCommitmentStatement := by
-  intro ag
-  simp [SubsidyV1.blockSubsidy]
+  refine ⟨?_, ?_, ?_⟩
+  · intro coinbaseWtxid rest
+    exact WitnessCommitmentV1.witnessMerkleRootWtxids_rewrites_coinbase_slot coinbaseWtxid rest
+  · intro pb witnessRoot gotCommit hRoot hCommit
+    exact WitnessCommitmentV1.checkWitnessCommitment_ok_iff
+      pb witnessRoot gotCommit hRoot hCommit
+  · intro blockBytes expectedPrevHash expectedTarget pb hParse hPow hTarget hPrev hMerkle
+    exact WitnessCommitmentV1.validateBlockBasic_witness_stage
+      blockBytes expectedPrevHash expectedTarget pb hParse hPow hTarget hPrev hMerkle
 
 theorem sighash_v1_proved : sighashV1Statement := by
   exact ⟨fun _ => rfl, fun _ => rfl⟩

--- a/RubinFormal/WitnessCommitmentV1.lean
+++ b/RubinFormal/WitnessCommitmentV1.lean
@@ -1,0 +1,208 @@
+import RubinFormal.BlockValidationOrder
+
+namespace RubinFormal
+
+open BlockBasicV1
+
+namespace WitnessCommitmentV1
+
+private theorem uint8_beq_eq_decide (x y : UInt8) :
+    BEq.beq x y = decide (x = y) := by
+  cases x with | mk xv =>
+  cases y with | mk yv =>
+  simp [BEq.beq]
+
+private theorem bytes_beq_refl (a : Bytes) : (a == a) = true := by
+  cases a with
+  | mk ad =>
+      show Array.isEqv ad ad BEq.beq = true
+      have h : (fun (x y : UInt8) => @BEq.beq UInt8 _ x y) = (fun x y => decide (x = y)) := by
+        funext x y; exact uint8_beq_eq_decide x y
+      have hrw : Array.isEqv ad ad BEq.beq = Array.isEqv ad ad (fun x y => decide (x = y)) := by
+        congr 1
+      rw [hrw]
+      exact Array.isEqv_self ad
+
+private theorem bytes_bne_self_false (a : Bytes) : (a != a) = false := by
+  show (!(a == a)) = false
+  rw [bytes_beq_refl]
+  rfl
+
+theorem coinbaseWitnessReservedValue_size :
+    coinbaseWitnessReservedValue.size = 32 := by
+  native_decide
+
+theorem witnessMerkleRootWtxids_rewrites_coinbase_slot
+    (coinbaseWtxid : Bytes) (rest : List Bytes) :
+    witnessMerkleRootWtxids (coinbaseWtxid :: rest) =
+      merkleRootTagged (coinbaseWitnessReservedValue :: rest) 0x02 0x03 := by
+  simp [witnessMerkleRootWtxids]
+
+theorem checkWitnessCommitment_rejects_mismatched_anchor
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hRoot : witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hNe : gotCommit ≠ witnessCommitmentHash witnessRoot) :
+    checkWitnessCommitment pb = .error "BLOCK_ERR_WITNESS_COMMITMENT" := by
+  unfold checkWitnessCommitment
+  rw [hRoot, hCommit]
+  have hMismatch : (gotCommit != witnessCommitmentHash witnessRoot) = true := by
+    cases hBool : (gotCommit != witnessCommitmentHash witnessRoot) with
+    | true =>
+        exact rfl
+    | false =>
+        have hEq : gotCommit = witnessCommitmentHash witnessRoot :=
+          RubinFormal.bne_false_eq gotCommit (witnessCommitmentHash witnessRoot) hBool
+        exact False.elim (hNe hEq)
+  simp only [Bind.bind, Except.bind, Pure.pure, Except.pure]
+  rw [hMismatch]
+  rfl
+
+theorem checkWitnessCommitment_ok_iff
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hRoot : witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit) :
+    checkWitnessCommitment pb = .ok () ↔
+      gotCommit = witnessCommitmentHash witnessRoot := by
+  unfold checkWitnessCommitment
+  rw [hRoot, hCommit]
+  cases hMismatch : (gotCommit != witnessCommitmentHash witnessRoot) with
+  | false =>
+      constructor
+      · intro _hOk
+        exact RubinFormal.bne_false_eq gotCommit (witnessCommitmentHash witnessRoot) hMismatch
+      · intro _hEq
+        simp [Bind.bind, Except.bind, Pure.pure, Except.pure, hMismatch, ite_false]
+  | true =>
+      constructor
+      · intro hOk
+        simp [Bind.bind, Except.bind, Pure.pure, Except.pure, hMismatch, ite_true] at hOk
+      · intro hEq
+        have hFalse : (gotCommit != witnessCommitmentHash witnessRoot) = false := by
+          subst hEq; exact bytes_bne_self_false _
+        rw [hFalse] at hMismatch
+        cases hMismatch
+
+theorem checkWitnessCommitment_accepts_matching_anchor
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hRoot : witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = witnessCommitmentHash witnessRoot) :
+    checkWitnessCommitment pb = .ok () := by
+  exact (checkWitnessCommitment_ok_iff pb witnessRoot gotCommit hRoot hCommit).2 hEq
+
+private theorem merkleGate_reduces_to_checkWitnessCommitment
+    (pb : ParsedBlock)
+    (hMerkle : merkleRootTxids pb.txids = .ok pb.header.merkleRoot) :
+    (do
+      let mr ← merkleRootTxids pb.txids
+      if mr != pb.header.merkleRoot then
+        throw "BLOCK_ERR_MERKLE_INVALID"
+      checkWitnessCommitment pb) = checkWitnessCommitment pb := by
+  rw [hMerkle]
+  have hSelf : (pb.header.merkleRoot != pb.header.merkleRoot) = false :=
+    bytes_bne_self_false _
+  simp [Bind.bind, Except.bind, Pure.pure, Except.pure, hSelf, ite_false]
+
+theorem validateBlockBasic_witness_stage
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (pb : ParsedBlock)
+    (hParse : parseBlock blockBytes = .ok pb)
+    (hPow : powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : merkleRootTxids pb.txids = .ok pb.header.merkleRoot) :
+    validateBlockBasic blockBytes expectedPrevHash expectedTarget = checkWitnessCommitment pb := by
+  cases expectedTarget with
+  | none =>
+      cases expectedPrevHash with
+      | none =>
+          have hTail := merkleGate_reduces_to_checkWitnessCommitment pb hMerkle
+          simpa [validateBlockBasic, Bind.bind, Except.bind, Pure.pure, Except.pure,
+            hParse, hPow] using hTail
+      | some prev =>
+          simp at hPrev
+          have hPrevFalse : (pb.header.prevHash != prev) = false := by
+            subst hPrev; exact bytes_bne_self_false _
+          have hTail := merkleGate_reduces_to_checkWitnessCommitment pb hMerkle
+          simpa [validateBlockBasic, Bind.bind, Except.bind, Pure.pure, Except.pure,
+            hParse, hPow, hPrevFalse] using hTail
+  | some target =>
+      simp at hTarget
+      have hTargetFalse : (pb.header.target != target) = false := by
+        subst hTarget; exact bytes_bne_self_false _
+      cases expectedPrevHash with
+      | none =>
+          have hTail := merkleGate_reduces_to_checkWitnessCommitment pb hMerkle
+          simpa [validateBlockBasic, Bind.bind, Except.bind, Pure.pure, Except.pure,
+            hParse, hPow, hTargetFalse] using hTail
+      | some prev =>
+          simp at hPrev
+          have hPrevFalse : (pb.header.prevHash != prev) = false := by
+            subst hPrev; exact bytes_bne_self_false _
+          have hTail := merkleGate_reduces_to_checkWitnessCommitment pb hMerkle
+          simpa [validateBlockBasic, Bind.bind, Except.bind, Pure.pure, Except.pure,
+            hParse, hPow, hTargetFalse, hPrevFalse] using hTail
+
+theorem validateBlockBasic_accepts_matching_anchor
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hParse : parseBlock blockBytes = .ok pb)
+    (hPow : powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hRoot : witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = witnessCommitmentHash witnessRoot) :
+    validateBlockBasic blockBytes expectedPrevHash expectedTarget = .ok () := by
+  rw [validateBlockBasic_witness_stage blockBytes expectedPrevHash expectedTarget pb
+    hParse hPow hTarget hPrev hMerkle]
+  exact checkWitnessCommitment_accepts_matching_anchor pb witnessRoot gotCommit hRoot hCommit hEq
+
+theorem validateBlockBasic_rejects_mismatched_anchor
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hParse : parseBlock blockBytes = .ok pb)
+    (hPow : powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hRoot : witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hNe : gotCommit ≠ witnessCommitmentHash witnessRoot) :
+    validateBlockBasic blockBytes expectedPrevHash expectedTarget =
+      .error "BLOCK_ERR_WITNESS_COMMITMENT" := by
+  rw [validateBlockBasic_witness_stage blockBytes expectedPrevHash expectedTarget pb
+    hParse hPow hTarget hPrev hMerkle]
+  exact checkWitnessCommitment_rejects_mismatched_anchor pb witnessRoot gotCommit hRoot hCommit hNe
+
+end WitnessCommitmentV1
+
+end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -70,15 +70,24 @@
     {
       "section_key": "witness_commitment",
       "section_heading": "### 10.4.1 Witness Commitment (Coinbase Anchor)",
-      "status": "stated",
+      "status": "proved",
       "theorems": [
+        "RubinFormal.witness_commitment_proved",
+        "RubinFormal.WitnessCommitmentV1.witnessMerkleRootWtxids_rewrites_coinbase_slot",
+        "RubinFormal.WitnessCommitmentV1.checkWitnessCommitment_ok_iff",
+        "RubinFormal.WitnessCommitmentV1.validateBlockBasic_witness_stage",
         "RubinFormal.Conformance.cv_block_basic_vectors_pass"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "notes": "Current registry entry is bounded to executable replay for witness-commitment enforcement in block-basic vectors.",
+      "theorem_files": {
+        "RubinFormal.WitnessCommitmentV1.witnessMerkleRootWtxids_rewrites_coinbase_slot": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean",
+        "RubinFormal.WitnessCommitmentV1.checkWitnessCommitment_ok_iff": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean",
+        "RubinFormal.WitnessCommitmentV1.validateBlockBasic_witness_stage": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean"
+      },
+      "notes": "Pinned section now has a standalone theorem surface for witness-merkle zeroing, isolated witness-step acceptance semantics, and reduction of validateBlockBasic to that step after earlier gates pass.",
       "limitations": [
-        "PinnedSections.bootstrap theorem for this section is intentionally too weak to count as a universal witness-commitment proof.",
-        "No standalone proof of full witness-commitment semantics is claimed here."
+        "The semantic surface proves the canonical witness-commitment step over the current BlockBasicV1 model, not cryptographic collision resistance of SHA3-256.",
+        "Executable replay remains complementary evidence for concrete fixture coverage and regression checking."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Q-FORMAL-WITNESS-COMMITMENT-SEMANTICS-01
- Adds `WitnessCommitmentV1.lean` with standalone witness-commitment theorems
- Extracts `checkWitnessCommitment` as isolated step in `BlockBasicV1`
- Updates `PinnedSections.lean` with 3-part `witnessCommitmentStatement`
- `proof_coverage.json`: witness_commitment `stated` → `proved`
- `lake build` passes, no `sorry`

## Theorems
1. `witnessMerkleRootWtxids_rewrites_coinbase_slot` — coinbase slot zeroing
2. `checkWitnessCommitment_ok_iff` — acceptance iff commitment matches
3. `checkWitnessCommitment_accepts_matching_anchor` — accept direction
4. `checkWitnessCommitment_rejects_mismatched_anchor` — reject direction
5. `validateBlockBasic_witness_stage` — reduction to witness step
6. `validateBlockBasic_accepts_matching_anchor` — full accept
7. `validateBlockBasic_rejects_mismatched_anchor` — full reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)