### PR TITLE
feat: merkle tag equivalence theorems

### DIFF
--- a/RubinFormal/BlockBasicV1.lean
+++ b/RubinFormal/BlockBasicV1.lean
@@ -206,8 +206,8 @@ def merkleRootTxids (txids : List Bytes) : Except String Bytes := do
 
 def merkleRootTagged (ids : List Bytes) (leafTag nodeTag : UInt8) : Except String Bytes := do
   if ids.isEmpty then throw "BLOCK_ERR_PARSE"
-  let leaf := fun (x : Bytes) => SHA3.sha3_256 ((ByteArray.empty.push leafTag) ++ x)
-  let node := fun (l r : Bytes) => SHA3.sha3_256 ((ByteArray.empty.push nodeTag) ++ l ++ r)
+  let leaf := fun (x : Bytes) => RubinFormal.Merkle.taggedLeafHash leafTag x
+  let node := fun (l r : Bytes) => RubinFormal.Merkle.taggedNodeHash nodeTag l r
   let mut level : List Bytes := ids.map leaf
   while level.length > 1 do
     let mut nxt : List Bytes := []

--- a/RubinFormal/MerkleStructure.lean
+++ b/RubinFormal/MerkleStructure.lean
@@ -51,10 +51,75 @@ theorem merkleRoot_termination_measure (level : List Bytes) (h : 2 ≤ level.len
 theorem leafTag_ne_nodeTag : (0x00 : UInt8) ≠ 0x01 := by
   decide
 
+theorem leafHash_txid_tag_equivalence (txid : Bytes) :
+    leafHash txid = SHA3.sha3_256 (txidLeafPreimage txid) := by
+  rfl
+
+theorem nodeHash_txid_tag_equivalence (l r : Bytes) :
+    nodeHash l r = SHA3.sha3_256 (txidNodePreimage l r) := by
+  rfl
+
 theorem leafHash_nodeHash_tag_domain (txid l r : Bytes) :
-    leafHash txid = SHA3.sha3_256 ((ByteArray.empty.push 0x00) ++ txid) ∧
-    nodeHash l r = SHA3.sha3_256 ((ByteArray.empty.push 0x01) ++ l ++ r) := by
+    leafHash txid = SHA3.sha3_256 (txidLeafPreimage txid) ∧
+    nodeHash l r = SHA3.sha3_256 (txidNodePreimage l r) := by
   constructor <;> rfl
+
+theorem wtxidLeafHash_wtxidNodeHash_tag_domain (wtxid l r : Bytes) :
+    wtxidLeafHash wtxid = SHA3.sha3_256 (wtxidLeafPreimage wtxid) ∧
+    wtxidNodeHash l r = SHA3.sha3_256 (wtxidNodePreimage l r) := by
+  constructor <;> rfl
+
+private theorem array_push_empty_append_get_zero (tag : UInt8) (rest : Array UInt8) :
+    (Array.push #[] tag ++ rest)[0]? = some tag := by
+  show (Array.push #[] tag ++ rest).data[0]? = some tag
+  rw [Array.append_data]
+  simp [Array.push, Array.data]
+
+private theorem tagged_leaf_first_byte (tag : UInt8) (rest : Bytes) :
+    (ByteArray.push ByteArray.empty tag ++ rest).data[0]? = some tag := by
+  simp [ByteArray.append, ByteArray.push, ByteArray.empty]
+  exact array_push_empty_append_get_zero tag rest.data
+
+private theorem tagged_node_first_byte (tag : UInt8) (l r : Bytes) :
+    (ByteArray.push ByteArray.empty tag ++ l ++ r).data[0]? = some tag := by
+  simp [ByteArray.append, ByteArray.push, ByteArray.empty]
+  -- Shape: (Array.push #[] tag ++ l.data ++ r.data)[0]?
+  -- (a ++ b ++ c) = (a ++ b) ++ c by Array.append_assoc
+  rw [Array.append_assoc]
+  exact array_push_empty_append_get_zero tag (l.data ++ r.data)
+
+theorem merkle_tag_equivalence_leaf_domains_disjoint (txid wtxid : Bytes) :
+    txidLeafPreimage txid ≠ wtxidLeafPreimage wtxid := by
+  intro h
+  have h0 := congrArg (fun bs => bs.data[0]?) h
+  simp only [txidLeafPreimage, wtxidLeafPreimage, taggedLeafPreimage] at h0
+  rw [tagged_leaf_first_byte 0x00 txid, tagged_leaf_first_byte 0x02 wtxid] at h0
+  cases h0
+
+theorem merkle_tag_equivalence_node_domains_disjoint
+    (txLeft txRight witLeft witRight : Bytes) :
+    txidNodePreimage txLeft txRight ≠ wtxidNodePreimage witLeft witRight := by
+  intro h
+  have h0 := congrArg (fun bs => bs.data[0]?) h
+  simp only [txidNodePreimage, wtxidNodePreimage, taggedNodePreimage] at h0
+  rw [tagged_node_first_byte 0x01 txLeft txRight,
+      tagged_node_first_byte 0x03 witLeft witRight] at h0
+  cases h0
+
+theorem merkle_tag_equivalence_leaf_collision_reduces_to_sha3_collision
+    (txid wtxid : Bytes)
+    (h : txidLeafHash txid = wtxidLeafHash wtxid) :
+    SHA3.sha3_256 (txidLeafPreimage txid) = SHA3.sha3_256 (wtxidLeafPreimage wtxid) ∧
+    txidLeafPreimage txid ≠ wtxidLeafPreimage wtxid := by
+  exact ⟨h, merkle_tag_equivalence_leaf_domains_disjoint txid wtxid⟩
+
+theorem merkle_tag_equivalence_node_collision_reduces_to_sha3_collision
+    (txLeft txRight witLeft witRight : Bytes)
+    (h : txidNodeHash txLeft txRight = wtxidNodeHash witLeft witRight) :
+    SHA3.sha3_256 (txidNodePreimage txLeft txRight) =
+        SHA3.sha3_256 (wtxidNodePreimage witLeft witRight) ∧
+    txidNodePreimage txLeft txRight ≠ wtxidNodePreimage witLeft witRight := by
+  exact ⟨h, merkle_tag_equivalence_node_domains_disjoint txLeft txRight witLeft witRight⟩
 
 end Merkle
 end RubinFormal

--- a/RubinFormal/MerkleV2.lean
+++ b/RubinFormal/MerkleV2.lean
@@ -6,11 +6,47 @@ namespace RubinFormal
 
 namespace Merkle
 
+def taggedLeafPreimage (tag : UInt8) (id : Bytes) : Bytes :=
+  (ByteArray.empty.push tag) ++ id
+
+def taggedNodePreimage (tag : UInt8) (l r : Bytes) : Bytes :=
+  (ByteArray.empty.push tag) ++ l ++ r
+
+def taggedLeafHash (tag : UInt8) (id : Bytes) : Bytes :=
+  SHA3.sha3_256 (taggedLeafPreimage tag id)
+
+def taggedNodeHash (tag : UInt8) (l r : Bytes) : Bytes :=
+  SHA3.sha3_256 (taggedNodePreimage tag l r)
+
+def txidLeafPreimage (txid : Bytes) : Bytes :=
+  taggedLeafPreimage 0x00 txid
+
+def txidNodePreimage (l r : Bytes) : Bytes :=
+  taggedNodePreimage 0x01 l r
+
+def wtxidLeafPreimage (wtxid : Bytes) : Bytes :=
+  taggedLeafPreimage 0x02 wtxid
+
+def wtxidNodePreimage (l r : Bytes) : Bytes :=
+  taggedNodePreimage 0x03 l r
+
+def txidLeafHash (txid : Bytes) : Bytes :=
+  taggedLeafHash 0x00 txid
+
+def txidNodeHash (l r : Bytes) : Bytes :=
+  taggedNodeHash 0x01 l r
+
+def wtxidLeafHash (wtxid : Bytes) : Bytes :=
+  taggedLeafHash 0x02 wtxid
+
+def wtxidNodeHash (l r : Bytes) : Bytes :=
+  taggedNodeHash 0x03 l r
+
 def leafHash (txid : Bytes) : Bytes :=
-  SHA3.sha3_256 ((ByteArray.empty.push 0x00) ++ txid)
+  txidLeafHash txid
 
 def nodeHash (l r : Bytes) : Bytes :=
-  SHA3.sha3_256 ((ByteArray.empty.push 0x01) ++ l ++ r)
+  txidNodeHash l r
 
 def reduceLevel (xs : List Bytes) : List Bytes :=
   match xs with

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -76,18 +76,23 @@
         "RubinFormal.WitnessCommitmentV1.witnessMerkleRootWtxids_rewrites_coinbase_slot",
         "RubinFormal.WitnessCommitmentV1.checkWitnessCommitment_ok_iff",
         "RubinFormal.WitnessCommitmentV1.validateBlockBasic_witness_stage",
-        "RubinFormal.Conformance.cv_block_basic_vectors_pass"
+        "RubinFormal.Conformance.cv_block_basic_vectors_pass",
+        "RubinFormal.Merkle.merkle_tag_equivalence_leaf_collision_reduces_to_sha3_collision",
+        "RubinFormal.Merkle.merkle_tag_equivalence_node_collision_reduces_to_sha3_collision"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.WitnessCommitmentV1.witnessMerkleRootWtxids_rewrites_coinbase_slot": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean",
         "RubinFormal.WitnessCommitmentV1.checkWitnessCommitment_ok_iff": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean",
-        "RubinFormal.WitnessCommitmentV1.validateBlockBasic_witness_stage": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean"
+        "RubinFormal.WitnessCommitmentV1.validateBlockBasic_witness_stage": "rubin-formal/RubinFormal/WitnessCommitmentV1.lean",
+        "RubinFormal.Merkle.merkle_tag_equivalence_leaf_collision_reduces_to_sha3_collision": "rubin-formal/RubinFormal/MerkleStructure.lean",
+        "RubinFormal.Merkle.merkle_tag_equivalence_node_collision_reduces_to_sha3_collision": "rubin-formal/RubinFormal/MerkleStructure.lean"
       },
-      "notes": "Pinned section now has a standalone theorem surface for witness-merkle zeroing, isolated witness-step acceptance semantics, and reduction of validateBlockBasic to that step after earlier gates pass.",
+      "notes": "Standalone witness-commitment theorems (PR#104) plus merkle tag domain-separation theorems showing txid tags (0x00/0x01) and witness-merkle tags (0x02/0x03) inhabit distinct SHA3 preimage domains.",
       "limitations": [
         "The semantic surface proves the canonical witness-commitment step over the current BlockBasicV1 model, not cryptographic collision resistance of SHA3-256.",
-        "Executable replay remains complementary evidence for concrete fixture coverage and regression checking."
+        "Executable replay remains complementary evidence for concrete fixture coverage and regression checking.",
+        "The merkle-tag theorems are structural domain-separation results only: cross-domain root equality would require a SHA3 collision."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Q-FORMAL-MERKLE-EQUIVALENCE-TAGS-01
- Domain-separation theorems for txid vs wtxid merkle tags
- Proves tags 0x00/0x01 (txid) and 0x02/0x03 (wtxid) inhabit distinct preimage domains
- Any cross-domain root equality implies SHA3 collision

## Theorems
1. `merkle_tag_equivalence_leaf_domains_disjoint` — leaf preimages disjoint
2. `merkle_tag_equivalence_node_domains_disjoint` — node preimages disjoint
3. `merkle_tag_equivalence_leaf_collision_reduces_to_sha3_collision`
4. `merkle_tag_equivalence_node_collision_reduces_to_sha3_collision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)