### PR TITLE
feat: add section25 validation totality theorem

### DIFF
--- a/RubinFormal/BlockValidationOrder.lean
+++ b/RubinFormal/BlockValidationOrder.lean
@@ -292,4 +292,43 @@ theorem section25_order_complete
             by simp [hPrev, hPrevEq],
             hMr, hMrEq, hWmr, hGotCommit, hCommitEq⟩
 
+def section25AcceptWitness
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes) : Prop :=
+  ∃ pb mr wmr gotCommit,
+    parseBlock blockBytes = .ok pb ∧
+    powCheck pb.header = .ok () ∧
+    (match expectedTarget with
+    | none => True
+    | some exp => pb.header.target = exp) ∧
+    (match expectedPrevHash with
+    | none => True
+    | some exp => pb.header.prevHash = exp) ∧
+    merkleRootTxids pb.txids = .ok mr ∧
+    mr = pb.header.merkleRoot ∧
+    witnessMerkleRootWtxids pb.wtxids = .ok wmr ∧
+    findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit ∧
+    gotCommit = witnessCommitmentHash wmr
+
+def section25ValidationTotalStatement : Prop :=
+  ∀ (blockBytes : Bytes) (expectedPrevHash expectedTarget : Option Bytes),
+    section25AcceptWitness blockBytes expectedPrevHash expectedTarget ∨
+      ∃ err, validateBlockBasic blockBytes expectedPrevHash expectedTarget = .error err
+
+theorem validateBlockBasic_accept_or_reject
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes) :
+    section25AcceptWitness blockBytes expectedPrevHash expectedTarget ∨
+      ∃ err, validateBlockBasic blockBytes expectedPrevHash expectedTarget = .error err := by
+  cases hRes : validateBlockBasic blockBytes expectedPrevHash expectedTarget with
+  | ok u =>
+      cases u
+      exact Or.inl (section25_order_complete blockBytes expectedPrevHash expectedTarget hRes)
+  | error err =>
+      exact Or.inr ⟨err, rfl⟩
+
+theorem section25_validation_total_proved : section25ValidationTotalStatement := by
+  intro blockBytes expectedPrevHash expectedTarget
+  exact validateBlockBasic_accept_or_reject blockBytes expectedPrevHash expectedTarget
+
 end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -302,6 +302,7 @@
       "section_heading": "## 25. Block Validation Order (Normative)",
       "status": "proved",
       "theorems": [
+        "RubinFormal.section25_validation_total_proved",
         "RubinFormal.SubsidyV1.connectBlock_end_to_end_proved",
         "RubinFormal.utxo_conservation_theorem",
         "RubinFormal.no_double_spend_theorem",
@@ -311,12 +312,14 @@
       ],
       "file": "rubin-formal/RubinFormal/SubsidyV1.lean",
       "theorem_files": {
+        "RubinFormal.section25_validation_total_proved": "rubin-formal/RubinFormal/BlockValidationOrder.lean",
         "RubinFormal.utxo_conservation_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.no_double_spend_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.prepareNonCoinbaseTxBasic_utxo_conserved": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.prepareNonCoinbaseTxBasic_inputs_available": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.scanInputs_no_intra_tx_double_spend": "rubin-formal/RubinFormal/ConnectBlockStrong.lean"
-      }
+      },
+      "notes": "Section 25 coverage now includes a standalone totality theorem for the BlockValidationOrder model: every input either produces the ordered acceptance witness from section25_order_complete or rejects with an explicit error returned by validateBlockBasic."
     }
   ],
   "proof_level": "refinement",


### PR DESCRIPTION
Q-FORMAL-VALIDATION-ORDER-THEOREM-01

## Summary
- add a top-level Section 25 totality theorem in BlockValidationOrder
- expose accept-or-reject coverage over validateBlockBasic using the existing ordered acceptance witness
- register the new theorem in proof_coverage.json

## Validation
- lake build