### PR TITLE
feat: add sighash commitment completeness theorems

### DIFF
--- a/RubinFormal/PinnedSections.lean
+++ b/RubinFormal/PinnedSections.lean
@@ -56,12 +56,51 @@ def witnessCommitmentStatement : Prop :=
     BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot →
     BlockBasicV1.validateBlockBasic blockBytes expectedPrevHash expectedTarget =
       BlockBasicV1.checkWitnessCommitment pb)
-/-- v2 (F-02 fix): sighash encoding size invariants over real `SighashV1.u64le`/`u32le`.
-    Fixed encoding sizes (8 and 4 bytes) are essential for preimage domain separation
-    in the sighash construction (`digestV1`). -/
+/-- v3 (D08-F04/D08-F10 fix): spec-level sighash commitment completeness.
+    (1) Fixed encoding sizes (8 and 4 bytes) remain canonical.
+    (2) Selector helpers for `ALL/NONE/SINGLE/ANYONECANPAY` choose the intended
+        input/output commitment scope over pre-hashed transaction components.
+    (3) Distinct declared transaction fields (`version`, `locktime`, input context,
+        output context including `sighash_type`) yield distinct preimage-frame parts.
+    This is a structural theorem surface over the hashed preimage builder; it does
+    not claim SHA3 collision resistance or full tx-level equivalence for every §12 path. -/
 def sighashV1Statement : Prop :=
   (∀ n : Nat, (SighashV1.u64le n).size = 8) ∧
-  (∀ n : Nat, (SighashV1.u32le n).size = 4)
+  (∀ n : Nat, (SighashV1.u32le n).size = 4) ∧
+  (∀ allInputs currentInput : Bytes,
+    SighashV1.selectHashPrevouts SighashV1.SIGHASH_ALL allInputs currentInput = some allInputs) ∧
+  (∀ allInputs currentInput : Bytes,
+    SighashV1.selectHashPrevouts SighashV1.SIGHASH_ALL_ANYONECANPAY allInputs currentInput = some currentInput) ∧
+  (∀ allInputs currentInput : Bytes,
+    SighashV1.selectHashSequences SighashV1.SIGHASH_NONE allInputs currentInput = some allInputs) ∧
+  (∀ allInputs currentInput : Bytes,
+    SighashV1.selectHashSequences SighashV1.SIGHASH_NONE_ANYONECANPAY allInputs currentInput = some currentInput) ∧
+  (∀ inputIndex outputCount : Nat, ∀ allOutputs selectedOutput emptyHash : Bytes,
+    SighashV1.selectHashOutputs SighashV1.SIGHASH_ALL inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some allOutputs) ∧
+  (∀ inputIndex outputCount : Nat, ∀ allOutputs selectedOutput emptyHash : Bytes,
+    SighashV1.selectHashOutputs SighashV1.SIGHASH_NONE inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some emptyHash) ∧
+  (∀ inputIndex outputCount : Nat, ∀ allOutputs selectedOutput emptyHash : Bytes,
+    inputIndex < outputCount →
+    SighashV1.selectHashOutputs SighashV1.SIGHASH_SINGLE inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some selectedOutput) ∧
+  (∀ inputIndex outputCount : Nat, ∀ allOutputs selectedOutput emptyHash : Bytes,
+    ¬ inputIndex < outputCount →
+    SighashV1.selectHashOutputs SighashV1.SIGHASH_SINGLE inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some emptyHash) ∧
+  (∀ a b : SighashV1.SighashPreimageFrame,
+    a.versionLE ≠ b.versionLE →
+    SighashV1.buildPreimageFrameParts a ≠ SighashV1.buildPreimageFrameParts b) ∧
+  (∀ a b : SighashV1.SighashPreimageFrame,
+    a.locktimeLE ≠ b.locktimeLE →
+    SighashV1.buildPreimageFrameParts a ≠ SighashV1.buildPreimageFrameParts b) ∧
+  (∀ a b : SighashV1.SighashPreimageFrame,
+    a.inputContextView ≠ b.inputContextView →
+    SighashV1.buildPreimageFrameParts a ≠ SighashV1.buildPreimageFrameParts b) ∧
+  (∀ a b : SighashV1.SighashPreimageFrame,
+    a.outputContextView ≠ b.outputContextView →
+    SighashV1.buildPreimageFrameParts a ≠ SighashV1.buildPreimageFrameParts b)
 def consensusErrorCodesStatement : Prop := ErrorCode.TxErrParse ≠ ErrorCode.TxErrSigInvalid
 def covenantRegistryStatement : Prop := CovenantType.P2PK ≠ CovenantType.HTLC
 def difficultyUpdateStatement : Prop :=
@@ -166,7 +205,31 @@ theorem witness_commitment_proved : witnessCommitmentStatement := by
       blockBytes expectedPrevHash expectedTarget pb hParse hPow hTarget hPrev hMerkle
 
 theorem sighash_v1_proved : sighashV1Statement := by
-  exact ⟨fun _ => rfl, fun _ => rfl⟩
+  refine ⟨fun _ => rfl, fun _ => rfl, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro allInputs currentInput
+    exact SighashV1.selectHashPrevouts_all_commits_all_inputs allInputs currentInput
+  · intro allInputs currentInput
+    exact SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input allInputs currentInput
+  · intro allInputs currentInput
+    exact SighashV1.selectHashSequences_all_commits_all_inputs allInputs currentInput
+  · intro allInputs currentInput
+    exact SighashV1.selectHashSequences_anyonecanpay_commits_current_input allInputs currentInput
+  · intro inputIndex outputCount allOutputs selectedOutput emptyHash
+    exact SighashV1.selectHashOutputs_all_commits_all_outputs inputIndex outputCount allOutputs selectedOutput emptyHash
+  · intro inputIndex outputCount allOutputs selectedOutput emptyHash
+    exact SighashV1.selectHashOutputs_none_commits_no_outputs inputIndex outputCount allOutputs selectedOutput emptyHash
+  · intro inputIndex outputCount allOutputs selectedOutput emptyHash h
+    exact SighashV1.selectHashOutputs_single_commits_selected_output inputIndex outputCount allOutputs selectedOutput emptyHash h
+  · intro inputIndex outputCount allOutputs selectedOutput emptyHash h
+    exact SighashV1.selectHashOutputs_single_oob_commits_empty inputIndex outputCount allOutputs selectedOutput emptyHash h
+  · intro a b h
+    exact SighashV1.buildPreimageFrameParts_commits_version a b h
+  · intro a b h
+    exact SighashV1.buildPreimageFrameParts_commits_locktime a b h
+  · intro a b h
+    exact SighashV1.buildPreimageFrameParts_commits_input_context a b h
+  · intro a b h
+    exact SighashV1.buildPreimageFrameParts_commits_output_context a b h
 
 theorem consensus_error_codes_proved : consensusErrorCodesStatement := by
   simpa [consensusErrorCodesStatement] using error_codes_distinct

--- a/RubinFormal/SighashV1.lean
+++ b/RubinFormal/SighashV1.lean
@@ -145,6 +145,65 @@ def hashOfDA (txKind : UInt8) : Bytes :=
     -- Not needed for current CV-SIGHASH vectors.
     SHA3.sha3_256 ByteArray.empty
 
+def SIGHASH_ALL : UInt8 := 0x01
+def SIGHASH_NONE : UInt8 := 0x02
+def SIGHASH_SINGLE : UInt8 := 0x03
+def SIGHASH_ANYONECANPAY : UInt8 := 0x80
+def SIGHASH_ALL_ANYONECANPAY : UInt8 := 0x81
+def SIGHASH_NONE_ANYONECANPAY : UInt8 := 0x82
+def SIGHASH_SINGLE_ANYONECANPAY : UInt8 := 0x83
+
+def selectHashPrevouts (sighashType : UInt8) (allInputs currentInput : Bytes) : Option Bytes :=
+  if _ : sighashType = SIGHASH_ALL_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_NONE_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_SINGLE_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_ALL then
+    some allInputs
+  else if _ : sighashType = SIGHASH_NONE then
+    some allInputs
+  else if _ : sighashType = SIGHASH_SINGLE then
+    some allInputs
+  else
+    none
+
+def selectHashSequences (sighashType : UInt8) (allInputs currentInput : Bytes) : Option Bytes :=
+  if _ : sighashType = SIGHASH_ALL_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_NONE_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_SINGLE_ANYONECANPAY then
+    some currentInput
+  else if _ : sighashType = SIGHASH_ALL then
+    some allInputs
+  else if _ : sighashType = SIGHASH_NONE then
+    some allInputs
+  else if _ : sighashType = SIGHASH_SINGLE then
+    some allInputs
+  else
+    none
+
+def selectHashOutputs
+    (sighashType : UInt8)
+    (inputIndex outputCount : Nat)
+    (allOutputs selectedOutput emptyHash : Bytes) : Option Bytes :=
+  if _ : sighashType = SIGHASH_ALL then
+    some allOutputs
+  else if _ : sighashType = SIGHASH_ALL_ANYONECANPAY then
+    some allOutputs
+  else if _ : sighashType = SIGHASH_NONE then
+    some emptyHash
+  else if _ : sighashType = SIGHASH_NONE_ANYONECANPAY then
+    some emptyHash
+  else if _ : sighashType = SIGHASH_SINGLE then
+    if inputIndex < outputCount then some selectedOutput else some emptyHash
+  else if _ : sighashType = SIGHASH_SINGLE_ANYONECANPAY then
+    if inputIndex < outputCount then some selectedOutput else some emptyHash
+  else
+    none
+
 structure SighashPreimageFrame where
   chainId : Bytes
   versionLE : Bytes
@@ -160,6 +219,7 @@ structure SighashPreimageFrame where
   sequenceLE : Bytes
   hashOutputs : Bytes
   locktimeLE : Bytes
+  sighashType : UInt8
 deriving Repr, DecidableEq
 
 def SighashPreimageFrame.WellFormed (f : SighashPreimageFrame) : Prop :=
@@ -193,7 +253,8 @@ def buildPreimageFrameParts (f : SighashPreimageFrame) : List Bytes :=
     f.inputValueLE,
     f.sequenceLE,
     f.hashOutputs,
-    f.locktimeLE
+    f.locktimeLE,
+    RubinFormal.bytes #[f.sighashType]
   ]
 
 def buildPreimageFrame (f : SighashPreimageFrame) : Bytes :=
@@ -208,6 +269,137 @@ theorem buildPreimageFrameParts_injective (a b : SighashPreimageFrame)
     | mk bChainId bVersionLE bTxKind bTxNonceLE bHashDA bHashPrevouts bHashSeq bInputIndexLE bPrevTxid bPrevVoutLE bInputValueLE bSequenceLE bHashOutputs bLocktimeLE =>
       simp [buildPreimageFrameParts, RubinFormal.bytes] at hEq ⊢
       simpa using hEq
+
+def SighashPreimageFrame.inputContextView (f : SighashPreimageFrame) :
+    Bytes × Bytes × Bytes × Bytes × Bytes × Bytes × Bytes :=
+  (f.hashPrevouts, f.hashSeq, f.inputIndexLE, f.prevTxid, f.prevVoutLE, f.inputValueLE, f.sequenceLE)
+
+def SighashPreimageFrame.outputContextView (f : SighashPreimageFrame) : Bytes × UInt8 :=
+  (f.hashOutputs, f.sighashType)
+
+def SighashPreimageFrame.declaredTxFieldView (f : SighashPreimageFrame) :
+    Bytes × Bytes × (Bytes × Bytes × Bytes × Bytes × Bytes × Bytes × Bytes) × (Bytes × UInt8) :=
+  (f.versionLE, f.locktimeLE, f.inputContextView, f.outputContextView)
+
+theorem selectHashPrevouts_all_commits_all_inputs
+    (allInputs currentInput : Bytes) :
+    selectHashPrevouts SIGHASH_ALL allInputs currentInput = some allInputs := by
+  have hAllAcp : ¬ (SIGHASH_ALL = SIGHASH_ALL_ANYONECANPAY) := by decide
+  have hNoneAcp : ¬ (SIGHASH_ALL = SIGHASH_NONE_ANYONECANPAY) := by decide
+  have hSingleAcp : ¬ (SIGHASH_ALL = SIGHASH_SINGLE_ANYONECANPAY) := by decide
+  have hAll : SIGHASH_ALL = SIGHASH_ALL := rfl
+  simp [selectHashPrevouts, hAllAcp, hNoneAcp, hSingleAcp, hAll]
+
+theorem selectHashPrevouts_anyonecanpay_commits_current_input
+    (allInputs currentInput : Bytes) :
+    selectHashPrevouts SIGHASH_ALL_ANYONECANPAY allInputs currentInput = some currentInput := by
+  have hAllAcp : SIGHASH_ALL_ANYONECANPAY = SIGHASH_ALL_ANYONECANPAY := rfl
+  simp [selectHashPrevouts, hAllAcp]
+
+theorem selectHashSequences_all_commits_all_inputs
+    (allInputs currentInput : Bytes) :
+    selectHashSequences SIGHASH_NONE allInputs currentInput = some allInputs := by
+  have hAllAcp : ¬ (SIGHASH_NONE = SIGHASH_ALL_ANYONECANPAY) := by decide
+  have hNoneAcp : ¬ (SIGHASH_NONE = SIGHASH_NONE_ANYONECANPAY) := by decide
+  have hSingleAcp : ¬ (SIGHASH_NONE = SIGHASH_SINGLE_ANYONECANPAY) := by decide
+  have hAll : ¬ (SIGHASH_NONE = SIGHASH_ALL) := by decide
+  have hNone : SIGHASH_NONE = SIGHASH_NONE := rfl
+  simp [selectHashSequences, hAllAcp, hNoneAcp, hSingleAcp, hAll, hNone]
+
+theorem selectHashSequences_anyonecanpay_commits_current_input
+    (allInputs currentInput : Bytes) :
+    selectHashSequences SIGHASH_NONE_ANYONECANPAY allInputs currentInput = some currentInput := by
+  have hNoneAcp : SIGHASH_NONE_ANYONECANPAY = SIGHASH_NONE_ANYONECANPAY := rfl
+  simp [selectHashSequences, hNoneAcp]
+
+theorem selectHashOutputs_all_commits_all_outputs
+    (inputIndex outputCount : Nat)
+    (allOutputs selectedOutput emptyHash : Bytes) :
+    selectHashOutputs SIGHASH_ALL inputIndex outputCount allOutputs selectedOutput emptyHash = some allOutputs := by
+  have hAll : SIGHASH_ALL = SIGHASH_ALL := rfl
+  simp [selectHashOutputs, hAll]
+
+theorem selectHashOutputs_none_commits_no_outputs
+    (inputIndex outputCount : Nat)
+    (allOutputs selectedOutput emptyHash : Bytes) :
+    selectHashOutputs SIGHASH_NONE inputIndex outputCount allOutputs selectedOutput emptyHash = some emptyHash := by
+  have hAll : ¬ (SIGHASH_NONE = SIGHASH_ALL) := by decide
+  have hAllAcp : ¬ (SIGHASH_NONE = SIGHASH_ALL_ANYONECANPAY) := by decide
+  have hNone : SIGHASH_NONE = SIGHASH_NONE := rfl
+  simp [selectHashOutputs, hAll, hAllAcp, hNone]
+
+theorem selectHashOutputs_single_commits_selected_output
+    (inputIndex outputCount : Nat)
+    (allOutputs selectedOutput emptyHash : Bytes)
+    (h : inputIndex < outputCount) :
+    selectHashOutputs SIGHASH_SINGLE inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some selectedOutput := by
+  have hAll : ¬ (SIGHASH_SINGLE = SIGHASH_ALL) := by decide
+  have hAllAcp : ¬ (SIGHASH_SINGLE = SIGHASH_ALL_ANYONECANPAY) := by decide
+  have hNone : ¬ (SIGHASH_SINGLE = SIGHASH_NONE) := by decide
+  have hNoneAcp : ¬ (SIGHASH_SINGLE = SIGHASH_NONE_ANYONECANPAY) := by decide
+  have hSingle : SIGHASH_SINGLE = SIGHASH_SINGLE := rfl
+  simp [selectHashOutputs, hAll, hAllAcp, hNone, hNoneAcp, hSingle, h]
+
+theorem selectHashOutputs_single_oob_commits_empty
+    (inputIndex outputCount : Nat)
+    (allOutputs selectedOutput emptyHash : Bytes)
+    (h : ¬ inputIndex < outputCount) :
+    selectHashOutputs SIGHASH_SINGLE inputIndex outputCount allOutputs selectedOutput emptyHash =
+      some emptyHash := by
+  have hAll : ¬ (SIGHASH_SINGLE = SIGHASH_ALL) := by decide
+  have hAllAcp : ¬ (SIGHASH_SINGLE = SIGHASH_ALL_ANYONECANPAY) := by decide
+  have hNone : ¬ (SIGHASH_SINGLE = SIGHASH_NONE) := by decide
+  have hNoneAcp : ¬ (SIGHASH_SINGLE = SIGHASH_NONE_ANYONECANPAY) := by decide
+  have hSingle : SIGHASH_SINGLE = SIGHASH_SINGLE := rfl
+  simp [selectHashOutputs, hAll, hAllAcp, hNone, hNoneAcp, hSingle, h]
+
+theorem buildPreimageFrameParts_eq_iff (a b : SighashPreimageFrame) :
+    buildPreimageFrameParts a = buildPreimageFrameParts b ↔ a = b := by
+  constructor
+  · exact buildPreimageFrameParts_injective a b
+  · intro h
+    simp [h]
+
+theorem buildPreimageFrameParts_commits_version
+    (a b : SighashPreimageFrame)
+    (h : a.versionLE ≠ b.versionLE) :
+    buildPreimageFrameParts a ≠ buildPreimageFrameParts b := by
+  intro hEq
+  apply h
+  exact congrArg SighashPreimageFrame.versionLE (buildPreimageFrameParts_injective a b hEq)
+
+theorem buildPreimageFrameParts_commits_locktime
+    (a b : SighashPreimageFrame)
+    (h : a.locktimeLE ≠ b.locktimeLE) :
+    buildPreimageFrameParts a ≠ buildPreimageFrameParts b := by
+  intro hEq
+  apply h
+  exact congrArg SighashPreimageFrame.locktimeLE (buildPreimageFrameParts_injective a b hEq)
+
+theorem buildPreimageFrameParts_commits_input_context
+    (a b : SighashPreimageFrame)
+    (h : a.inputContextView ≠ b.inputContextView) :
+    buildPreimageFrameParts a ≠ buildPreimageFrameParts b := by
+  intro hEq
+  apply h
+  exact congrArg SighashPreimageFrame.inputContextView (buildPreimageFrameParts_injective a b hEq)
+
+theorem buildPreimageFrameParts_commits_output_context
+    (a b : SighashPreimageFrame)
+    (h : a.outputContextView ≠ b.outputContextView) :
+    buildPreimageFrameParts a ≠ buildPreimageFrameParts b := by
+  intro hEq
+  apply h
+  exact congrArg SighashPreimageFrame.outputContextView (buildPreimageFrameParts_injective a b hEq)
+
+theorem buildPreimageFrameParts_commits_declared_tx_fields
+    (a b : SighashPreimageFrame)
+    (h : a.declaredTxFieldView ≠ b.declaredTxFieldView) :
+    buildPreimageFrameParts a ≠ buildPreimageFrameParts b := by
+  intro hEq
+  apply h
+  exact congrArg SighashPreimageFrame.declaredTxFieldView (buildPreimageFrameParts_injective a b hEq)
 
 def digestV1 (tx : Bytes) (chainId : Bytes) (inputIndex : Nat) (inputValue : Nat) : Except String Bytes := do
   let core ← parseTxCoreForSighash tx

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -100,22 +100,48 @@
       "section_heading": "## 12. Sighash v1 (Normative)",
       "status": "stated",
       "theorems": [
-      "RubinFormal.Conformance.cv_sighash_vectors_pass",
-      "RubinFormal.digestV1_deterministic",
-      "RubinFormal.SighashV1.buildPreimageFrameParts_injective"
-    ],
-    "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-    "theorem_files": {
-      "RubinFormal.digestV1_deterministic": "rubin-formal/RubinFormal/SighashV1.lean",
-      "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean"
+        "RubinFormal.Conformance.cv_sighash_vectors_pass",
+        "RubinFormal.digestV1_deterministic",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_injective",
+        "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs",
+        "RubinFormal.SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input",
+        "RubinFormal.SighashV1.selectHashSequences_all_commits_all_inputs",
+        "RubinFormal.SighashV1.selectHashSequences_anyonecanpay_commits_current_input",
+        "RubinFormal.SighashV1.selectHashOutputs_all_commits_all_outputs",
+        "RubinFormal.SighashV1.selectHashOutputs_none_commits_no_outputs",
+        "RubinFormal.SighashV1.selectHashOutputs_single_commits_selected_output",
+        "RubinFormal.SighashV1.selectHashOutputs_single_oob_commits_empty",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_version",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_locktime",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_input_context",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_output_context",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_declared_tx_fields"
+      ],
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "theorem_files": {
+        "RubinFormal.digestV1_deterministic": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashSequences_all_commits_all_inputs": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashSequences_anyonecanpay_commits_current_input": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashOutputs_all_commits_all_outputs": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashOutputs_none_commits_no_outputs": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashOutputs_single_commits_selected_output": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.selectHashOutputs_single_oob_commits_empty": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_version": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_locktime": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_input_context": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_output_context": "rubin-formal/RubinFormal/SighashV1.lean",
+        "RubinFormal.SighashV1.buildPreimageFrameParts_commits_declared_tx_fields": "rubin-formal/RubinFormal/SighashV1.lean"
+      },
+      "notes": "Claim is limited to executable replay on the current CV-SIGHASH fixture subset plus a stronger spec-level theorem surface for the typed preimage-frame builder: selector helpers now cover `ALL/NONE/SINGLE/ANYONECANPAY`, and dedicated corollaries show that version, locktime, input context, and output context including `sighash_type` are all committed in the segmented fixed-width preimage parts.",
+      "limitations": [
+        "The executable `digestV1` replay path still covers the current fixture subset and is not yet a universal tx-level equivalence proof for every §12 `sighash_type` branch or invalid-type rejection path.",
+        "The strengthened theorems are structural over pre-hashed components and segmented preimage parts, not a claim about cryptographic collision resistance of SHA3-256.",
+        "No universal proof is claimed here for deriving all hashed components directly from arbitrary raw transactions, DaCoreFieldsBytes, or witness-carried `sighash_type` extraction."
+      ]
     },
-    "notes": "Claim is limited to executable replay on the conformance fixture set plus determinism of digestV1 and a standalone injectivity theorem for the segmented fixed-width preimage frame builder before final byte concatenation and the final SHA3-256 call.",
-    "limitations": [
-      "The bootstrap size-invariant theorem in PinnedSections is not treated as a full sighash correctness proof.",
-      "No universal equivalence proof for every §12 case beyond conformance replay is claimed.",
-      "The injectivity theorem is over the segmented fixed-width preimage frame builder after field-by-field byte encoding, not over arbitrary raw transactions, fully concatenated preimage bytes, or cryptographic collision resistance."
-    ]
-  },
     {
       "section_key": "consensus_error_codes",
       "section_heading": "## 13. Consensus Error Codes (Normative)",


### PR DESCRIPTION
## Summary
- add spec-level sighash selector theorems for `ALL/NONE/SINGLE/ANYONECANPAY`
- strengthen the pinned `sighash_v1` theorem surface with explicit commitment corollaries for version, locktime, input context, and output context
- update `proof_coverage.json` to reflect the stronger theorem surface while keeping the section claim conservatively `stated`

## Validation
- `lake build`
- no `sorry`

Q-FORMAL-SIGHASH-COMMITMENT-01