### PR TITLE
feat: CompactSize encode roundtrip theorems

### DIFF
--- a/RubinFormal/ByteWireV2.lean
+++ b/RubinFormal/ByteWireV2.lean
@@ -1,4 +1,5 @@
 import RubinFormal.Types
+import RubinFormal.OutputDescriptorV2
 import Std.Tactic.Omega
 
 namespace RubinFormal
@@ -33,14 +34,15 @@ def u32le? (b0 b1 b2 b3 : UInt8) : Nat :=
   (b0.toNat) + (b1.toNat <<< 8) + (b2.toNat <<< 16) + (b3.toNat <<< 24)
 
 def u64le? (b0 b1 b2 b3 b4 b5 b6 b7 : UInt8) : UInt64 :=
-  (UInt64.ofNat b0.toNat) |||
-  ((UInt64.ofNat b1.toNat) <<< 8) |||
-  ((UInt64.ofNat b2.toNat) <<< 16) |||
-  ((UInt64.ofNat b3.toNat) <<< 24) |||
-  ((UInt64.ofNat b4.toNat) <<< 32) |||
-  ((UInt64.ofNat b5.toNat) <<< 40) |||
-  ((UInt64.ofNat b6.toNat) <<< 48) |||
-  ((UInt64.ofNat b7.toNat) <<< 56)
+  UInt64.ofNat (
+    b0.toNat +
+    (b1.toNat <<< 8) +
+    (b2.toNat <<< 16) +
+    (b3.toNat <<< 24) +
+    (b4.toNat <<< 32) +
+    (b5.toNat <<< 40) +
+    (b6.toNat <<< 48) +
+    (b7.toNat <<< 56))
 
 def Cursor.getU32le? (c : Cursor) : Option (Nat × Cursor) := do
   let (bs, c') ← c.getBytes? 4
@@ -272,6 +274,305 @@ theorem compactSize_overflow_safety {bs : Bytes} {n : Nat} (h : CompactSizeCanon
   | threeByte _ _ _ hBound => exact hBound
   | fiveByte _ _ _ _ _ hBound => exact hBound
   | nineByte _ _ _ _ _ _ _ _ _ hBound => exact hBound
+
+open WireEnc
+
+private theorem uint8_ofNat_toNat_eq (n : Nat) (h : n < 256) :
+    (UInt8.ofNat n).toNat = n := by
+  simp [UInt8.ofNat, UInt8.toNat, Fin.ofNat, Nat.mod_eq_of_lt h]
+
+private theorem u16le_ofNat_roundtrip (n : Nat) (h : n ≤ 0xffff) :
+    u16le? (UInt8.ofNat (n % 256)) (UInt8.ofNat ((n / 256) % 256)) = n := by
+  have h0 : n % 256 < 256 := Nat.mod_lt _ (by decide)
+  have h1div : n / 256 < 256 := by omega
+  have h1 : (UInt8.ofNat ((n / 256) % 256)).toNat = n / 256 := by
+    simpa [Nat.mod_eq_of_lt h1div] using
+      uint8_ofNat_toNat_eq ((n / 256) % 256) (Nat.mod_lt _ (by decide))
+  calc
+    u16le? (UInt8.ofNat (n % 256)) (UInt8.ofNat ((n / 256) % 256))
+      = (UInt8.ofNat (n % 256)).toNat + ((UInt8.ofNat ((n / 256) % 256)).toNat <<< 8) := by
+          rfl
+    _ = n % 256 + ((n / 256) <<< 8) := by
+          rw [uint8_ofNat_toNat_eq (n % 256) h0, h1]
+    _ = n % 256 + (n / 256) * 256 := by
+          rw [Nat.shiftLeft_eq, show 2 ^ 8 = 256 by decide]
+    _ = n := by
+          simpa [Nat.mul_comm] using Nat.mod_add_div n 256
+
+private theorem u32le_ofNat_roundtrip (n : Nat) (h : n ≤ 0xffffffff) :
+    u32le?
+      (UInt8.ofNat (n % 256))
+      (UInt8.ofNat ((n / 256) % 256))
+      (UInt8.ofNat ((n / 65536) % 256))
+      (UInt8.ofNat ((n / 16777216) % 256)) = n := by
+  have h0 : n % 256 < 256 := Nat.mod_lt _ (by decide)
+  have h1 : (n / 256) % 256 < 256 := Nat.mod_lt _ (by decide)
+  have h2 : (n / 65536) % 256 < 256 := Nat.mod_lt _ (by decide)
+  have h3div : n / 16777216 < 256 := by omega
+  have h3 : (UInt8.ofNat ((n / 16777216) % 256)).toNat = n / 16777216 := by
+    simpa [Nat.mod_eq_of_lt h3div] using
+      uint8_ofNat_toNat_eq ((n / 16777216) % 256) (Nat.mod_lt _ (by decide))
+  have hq1 : (n / 256) % 256 + 256 * (n / 65536) = n / 256 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 256) 256
+  have hq2 : (n / 65536) % 256 + 256 * (n / 16777216) = n / 65536 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 65536) 256
+  have hFlatToNested :
+      n % 256 +
+      ((n / 256) % 256 * 256) +
+      ((n / 65536) % 256 * 65536) +
+      ((n / 16777216) * 16777216) =
+      n % 256 + 256 * ((n / 256) % 256 + 256 * ((n / 65536) % 256 + 256 * (n / 16777216))) := by
+    omega
+  have hNestedEq :
+      n % 256 + 256 * ((n / 256) % 256 + 256 * ((n / 65536) % 256 + 256 * (n / 16777216))) = n := by
+    rw [hq2, hq1, Nat.mod_add_div]
+  calc
+    u32le?
+      (UInt8.ofNat (n % 256))
+      (UInt8.ofNat ((n / 256) % 256))
+      (UInt8.ofNat ((n / 65536) % 256))
+      (UInt8.ofNat ((n / 16777216) % 256))
+      =
+      n % 256 +
+      ((n / 256) % 256 * 256) +
+      ((n / 65536) % 256 * 65536) +
+      ((n / 16777216) * 16777216) := by
+          unfold u32le?
+          rw [uint8_ofNat_toNat_eq (n % 256) h0]
+          rw [uint8_ofNat_toNat_eq ((n / 256) % 256) h1]
+          rw [uint8_ofNat_toNat_eq ((n / 65536) % 256) h2]
+          rw [h3]
+          rw [Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftLeft_eq]
+          rw [show 2 ^ 8 = 256 by decide,
+              show 2 ^ 16 = 65536 by decide,
+              show 2 ^ 24 = 16777216 by decide]
+    _ = n % 256 + 256 * ((n / 256) % 256 + 256 * ((n / 65536) % 256 + 256 * (n / 16777216))) := by
+          exact hFlatToNested
+    _ = n := hNestedEq
+
+private theorem u64_digits_nested_eq (n : Nat) (h : n ≤ UInt64.size - 1) :
+    n % 256 +
+      256 * ((n / 256) % 256 +
+      256 * ((n / 65536) % 256 +
+      256 * ((n / 16777216) % 256 +
+      256 * ((n / 4294967296) % 256 +
+      256 * ((n / 1099511627776) % 256 +
+      256 * ((n / 281474976710656) % 256 +
+      256 * ((n / 72057594037927936) % 256))))))) = n := by
+  have hlt : n < UInt64.size := Nat.lt_of_le_of_lt h (by decide)
+  have h7div : n / 72057594037927936 < 256 := by
+    exact
+      (Nat.div_lt_iff_lt_mul (x := n) (y := 256) (k := 72057594037927936) (by decide)).2
+        (by simpa [UInt64.size, Nat.mul_comm] using hlt)
+  have hq0 : n % 256 + 256 * (n / 256) = n := Nat.mod_add_div n 256
+  have hq1 : (n / 256) % 256 + 256 * (n / 65536) = n / 256 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 256) 256
+  have hq2 : (n / 65536) % 256 + 256 * (n / 16777216) = n / 65536 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 65536) 256
+  have hq3 : (n / 16777216) % 256 + 256 * (n / 4294967296) = n / 16777216 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 16777216) 256
+  have hq4 : (n / 4294967296) % 256 + 256 * (n / 1099511627776) = n / 4294967296 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 4294967296) 256
+  have hq5 : (n / 1099511627776) % 256 + 256 * (n / 281474976710656) = n / 1099511627776 := by
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 1099511627776) 256
+  have hq6 : (n / 281474976710656) % 256 + 256 * ((n / 72057594037927936) % 256) =
+      n / 281474976710656 := by
+    rw [Nat.mod_eq_of_lt h7div]
+    simpa [Nat.div_div_eq_div_mul, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+      Nat.mod_add_div (n / 281474976710656) 256
+  rw [hq6, hq5, hq4, hq3, hq2, hq1, hq0]
+
+private theorem u64_digits_flat_eq (n : Nat) (h : n ≤ UInt64.size - 1) :
+    n % 256 +
+    ((n / 256) % 256 * 256) +
+    ((n / 65536) % 256 * 65536) +
+    ((n / 16777216) % 256 * 16777216) +
+    ((n / 4294967296) % 256 * 4294967296) +
+    ((n / 1099511627776) % 256 * 1099511627776) +
+    ((n / 281474976710656) % 256 * 281474976710656) +
+    ((n / 72057594037927936) % 256 * 72057594037927936) = n := by
+  have hNested := u64_digits_nested_eq n h
+  have hFlatToNested :
+      n % 256 +
+      (n / 256 % 256) * 256 +
+      (n / 65536 % 256) * 65536 +
+      (n / 16777216 % 256) * 16777216 +
+      (n / 4294967296 % 256) * 4294967296 +
+      (n / 1099511627776 % 256) * 1099511627776 +
+      (n / 281474976710656 % 256) * 281474976710656 +
+      (n / 72057594037927936 % 256) * 72057594037927936 =
+      n % 256 +
+        256 * ((n / 256) % 256 +
+        256 * ((n / 65536) % 256 +
+        256 * ((n / 16777216) % 256 +
+        256 * ((n / 4294967296) % 256 +
+        256 * ((n / 1099511627776) % 256 +
+        256 * ((n / 281474976710656) % 256 +
+        256 * ((n / 72057594037927936) % 256))))))) := by
+    omega
+  exact hFlatToNested.trans hNested
+
+private theorem u64le_ofNat_roundtrip (n : Nat) (h : n ≤ UInt64.size - 1) :
+    (u64le?
+      (UInt8.ofNat (n % 256))
+      (UInt8.ofNat ((n / 256) % 256))
+      (UInt8.ofNat ((n / 65536) % 256))
+      (UInt8.ofNat ((n / 16777216) % 256))
+      (UInt8.ofNat ((n / 4294967296) % 256))
+      (UInt8.ofNat ((n / 1099511627776) % 256))
+      (UInt8.ofNat ((n / 281474976710656) % 256))
+      (UInt8.ofNat ((n / 72057594037927936) % 256))).toNat = n := by
+  have hb0 : (UInt8.ofNat (n % 256)).toNat = n % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb1 : (UInt8.ofNat ((n / 256) % 256)).toNat = (n / 256) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb2 : (UInt8.ofNat ((n / 65536) % 256)).toNat = (n / 65536) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb3 : (UInt8.ofNat ((n / 16777216) % 256)).toNat = (n / 16777216) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb4 : (UInt8.ofNat ((n / 4294967296) % 256)).toNat = (n / 4294967296) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb5 : (UInt8.ofNat ((n / 1099511627776) % 256)).toNat = (n / 1099511627776) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb6 : (UInt8.ofNat ((n / 281474976710656) % 256)).toNat = (n / 281474976710656) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hb7 : (UInt8.ofNat ((n / 72057594037927936) % 256)).toNat = (n / 72057594037927936) % 256 := by
+    exact uint8_ofNat_toNat_eq _ (Nat.mod_lt _ (by decide))
+  have hFlat := u64_digits_flat_eq n h
+  have hSumLt :
+      n % 256 +
+      ((n / 256) % 256 * 256) +
+      ((n / 65536) % 256 * 65536) +
+      ((n / 16777216) % 256 * 16777216) +
+      ((n / 4294967296) % 256 * 4294967296) +
+      ((n / 1099511627776) % 256 * 1099511627776) +
+      ((n / 281474976710656) % 256 * 281474976710656) +
+      ((n / 72057594037927936) % 256 * 72057594037927936) < UInt64.size := by
+    simpa [hFlat] using Nat.lt_of_le_of_lt h (by decide)
+  calc
+    (u64le?
+      (UInt8.ofNat (n % 256))
+      (UInt8.ofNat ((n / 256) % 256))
+      (UInt8.ofNat ((n / 65536) % 256))
+      (UInt8.ofNat ((n / 16777216) % 256))
+      (UInt8.ofNat ((n / 4294967296) % 256))
+      (UInt8.ofNat ((n / 1099511627776) % 256))
+      (UInt8.ofNat ((n / 281474976710656) % 256))
+      (UInt8.ofNat ((n / 72057594037927936) % 256))).toNat
+      =
+      (UInt64.ofNat (
+        n % 256 +
+        ((n / 256) % 256 * 256) +
+        ((n / 65536) % 256 * 65536) +
+        ((n / 16777216) % 256 * 16777216) +
+        ((n / 4294967296) % 256 * 4294967296) +
+        ((n / 1099511627776) % 256 * 1099511627776) +
+        ((n / 281474976710656) % 256 * 281474976710656) +
+        ((n / 72057594037927936) % 256 * 72057594037927936))).toNat := by
+          unfold u64le?
+          rw [hb0, hb1, hb2, hb3, hb4, hb5, hb6, hb7]
+          rw [Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftLeft_eq,
+              Nat.shiftLeft_eq, Nat.shiftLeft_eq, Nat.shiftLeft_eq]
+          rw [show 2 ^ 8 = 256 by decide,
+              show 2 ^ 16 = 65536 by decide,
+              show 2 ^ 24 = 16777216 by decide,
+              show 2 ^ 32 = 4294967296 by decide,
+              show 2 ^ 40 = 1099511627776 by decide,
+              show 2 ^ 48 = 281474976710656 by decide,
+              show 2 ^ 56 = 72057594037927936 by decide]
+  _ =
+      n % 256 +
+      ((n / 256) % 256 * 256) +
+      ((n / 65536) % 256 * 65536) +
+      ((n / 16777216) % 256 * 16777216) +
+      ((n / 4294967296) % 256 * 4294967296) +
+      ((n / 1099511627776) % 256 * 1099511627776) +
+      ((n / 281474976710656) % 256 * 281474976710656) +
+      ((n / 72057594037927936) % 256 * 72057594037927936) := by
+          have hSumLtAssoc :
+              n % 256 +
+                (n / 256 % 256 * 256 +
+                  (n / 65536 % 256 * 65536 +
+                    (n / 16777216 % 256 * 16777216 +
+                      (n / 4294967296 % 256 * 4294967296 +
+                        (n / 1099511627776 % 256 * 1099511627776 +
+                          (n / 281474976710656 % 256 * 281474976710656 +
+                            n / 72057594037927936 % 256 * 72057594037927936)))))) < UInt64.size := by
+            omega
+          simp [UInt64.ofNat, UInt64.toNat, Fin.ofNat, Nat.mod_eq_of_lt hSumLtAssoc, Nat.add_assoc]
+    _ = n := hFlat
+
+set_option maxHeartbeats 20000000 in
+theorem compactSize_encode_roundtrip (n : Nat) (hBound : n ≤ UInt64.size - 1) :
+    ({ bs := WireEnc.compactSize n, off := 0 } : Cursor).getCompactSize? =
+      some (n, { bs := WireEnc.compactSize n, off := (WireEnc.compactSize n).size }, true) := by
+  by_cases hOne : n < 0xfd
+  · have hByte : (UInt8.ofNat n).toNat < 0xfd := by
+      simpa [uint8_ofNat_toNat_eq n (Nat.lt_of_lt_of_le hOne (by decide))] using hOne
+    simpa [WireEnc.compactSize, hOne, uint8_ofNat_toNat_eq n (Nat.lt_of_lt_of_le hOne (by decide))] using
+      compactSize_one_byte_roundtrip (UInt8.ofNat n) hByte
+  · by_cases hThree : n ≤ 0xffff
+    · have hMin : 0xfd ≤ u16le? (UInt8.ofNat (n % 256)) (UInt8.ofNat ((n / 256) % 256)) := by
+        simpa [u16le_ofNat_roundtrip n hThree] using Nat.not_lt.mp hOne
+      simpa [WireEnc.compactSize, hOne, hThree, u16le_ofNat_roundtrip n hThree] using
+        compactSize_three_byte_roundtrip
+          (UInt8.ofNat (n % 256))
+          (UInt8.ofNat ((n / 256) % 256))
+          hMin
+    · by_cases hFive : n ≤ 0xffffffff
+      · have hMin :
+          0xffff <
+            u32le?
+              (UInt8.ofNat (n % 256))
+              (UInt8.ofNat ((n / 256) % 256))
+              (UInt8.ofNat ((n / 65536) % 256))
+              (UInt8.ofNat ((n / 16777216) % 256)) := by
+          simpa [u32le_ofNat_roundtrip n hFive] using Nat.lt_of_not_ge hThree
+        simpa [WireEnc.compactSize, hOne, hThree, hFive, u32le_ofNat_roundtrip n hFive] using
+          compactSize_five_byte_roundtrip
+            (UInt8.ofNat (n % 256))
+            (UInt8.ofNat ((n / 256) % 256))
+            (UInt8.ofNat ((n / 65536) % 256))
+            (UInt8.ofNat ((n / 16777216) % 256))
+            hMin
+      · have hMin :
+          0xffffffff <
+            (u64le?
+              (UInt8.ofNat (n % 256))
+              (UInt8.ofNat ((n / 256) % 256))
+              (UInt8.ofNat ((n / 65536) % 256))
+              (UInt8.ofNat ((n / 16777216) % 256))
+              (UInt8.ofNat ((n / 4294967296) % 256))
+              (UInt8.ofNat ((n / 1099511627776) % 256))
+              (UInt8.ofNat ((n / 281474976710656) % 256))
+              (UInt8.ofNat ((n / 72057594037927936) % 256))).toNat := by
+          simpa [u64le_ofNat_roundtrip n hBound] using Nat.lt_of_not_ge hFive
+        have hRound :=
+          compactSize_nine_byte_roundtrip
+            (UInt8.ofNat (n % 256))
+            (UInt8.ofNat ((n / 256) % 256))
+            (UInt8.ofNat ((n / 65536) % 256))
+            (UInt8.ofNat ((n / 16777216) % 256))
+            (UInt8.ofNat ((n / 4294967296) % 256))
+            (UInt8.ofNat ((n / 1099511627776) % 256))
+            (UInt8.ofNat ((n / 281474976710656) % 256))
+            (UInt8.ofNat ((n / 72057594037927936) % 256))
+            hMin
+        rw [u64le_ofNat_roundtrip n hBound] at hRound
+        simpa [WireEnc.compactSize, WireEnc.u64le, hOne, hThree, hFive, RubinFormal.bytes] using hRound
+
+theorem compactSize_encode_cursor_advances (n : Nat) (hBound : n ≤ UInt64.size - 1) :
+    ({ bs := WireEnc.compactSize n, off := 0 } : Cursor).getCompactSize? =
+      some (n, { bs := WireEnc.compactSize n, off := (WireEnc.compactSize n).size }, true) ∧
+      ({ bs := WireEnc.compactSize n, off := 0 } : Cursor).remaining = (WireEnc.compactSize n).size := by
+  refine ⟨compactSize_encode_roundtrip n hBound, rfl⟩
 
 -- ═══════════════════════════════════════════════════════════════════
 -- ByteWireV2 structural theorems (F-05 fix, Q-FORMAL-GAP-04)

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -35,17 +35,21 @@
         "RubinFormal.Conformance.cv_compact_vectors_pass",
         "RubinFormal.sem001_mldsa_bounded_lengths_proved",
         "RubinFormal.Wire.compactSize_roundtrip",
-        "RubinFormal.Wire.compactSize_overflow_safety"
+        "RubinFormal.Wire.compactSize_overflow_safety",
+        "RubinFormal.Wire.compactSize_encode_roundtrip",
+        "RubinFormal.Wire.compactSize_encode_cursor_advances"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.sem001_mldsa_bounded_lengths_proved": "rubin-formal/RubinFormal/FormalGap03.lean",
         "RubinFormal.Wire.compactSize_roundtrip": "rubin-formal/RubinFormal/ByteWireV2.lean",
-        "RubinFormal.Wire.compactSize_overflow_safety": "rubin-formal/RubinFormal/ByteWireV2.lean"
+        "RubinFormal.Wire.compactSize_overflow_safety": "rubin-formal/RubinFormal/ByteWireV2.lean",
+        "RubinFormal.Wire.compactSize_encode_roundtrip": "rubin-formal/RubinFormal/ByteWireV2.lean",
+        "RubinFormal.Wire.compactSize_encode_cursor_advances": "rubin-formal/RubinFormal/ByteWireV2.lean"
       },
       "limitations": [
         "The deprecated shim ByteWire.lean is not a proof surface; the toy bootstrap model lives in ByteWireLegacy.lean.",
-        "Byte-accurate claim is limited to the listed replay and ByteWireV2 theorems."
+        "Byte-accurate claim is limited to the listed replay and ByteWireV2 framing theorems; no full transaction parse-serialize roundtrip is claimed."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Q-FORMAL-BYTEWIREV2-ROUNDTRIP-01
- CompactSize framing-level roundtrip theorems for ByteWireV2
- `compactSize_encode_roundtrip`: parseCompactSize(compactSize(n)) = n
- `compactSize_encode_cursor_advances`: cursor advances correctly past prefix
- Narrowed scope: framing-level, not full tx parse-serialize roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)