### PR TITLE
ci: expand claude-review prompt, restrict to .lean files

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,8 @@ name: "Claude Code Review"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.lean'
 
 permissions:
   contents: read
@@ -15,23 +17,66 @@ jobs:
     name: claude
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Run Claude Code Review
         id: review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_MODEL: claude-sonnet-4-6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-                    model: claude-opus-4-6
+          claude_args: "--max-turns 15"
           prompt: |
             You are a senior formal verification engineer and Lean 4 expert reviewing changes to the RUBIN blockchain protocol formal specification.
-            Focus on:
-            - Correctness of Lean 4 proofs and theorem statements
-            - Logical consistency with the RUBIN protocol specification
-            - Missing edge cases or unprovable lemmas
-            - Type errors and universe inconsistencies
-            - Security-critical invariants that must be preserved
-            - Post-quantum cryptography assumptions and their formal encoding
-            Be precise and reference specific line numbers. Flag any proof that uses `sorry` or `admit`.
+
+            ## Architecture
+
+            RUBIN uses Lean 4 v4.6.0 with std4 (no Mathlib) for formal verification of consensus rules.
+            - Canonical spec: RUBIN_L1_CANONICAL.md (private) -> Go reference client -> Rust parity client -> conformance vectors -> formal proofs
+            - Proof files: RubinFormal/ -- block validation, UTXO, merkle, witness commitment, sighash, covenants
+            - Conformance replay: native_decide for all gates (NOT #eval + trivial)
+            - Refinement bridge: Go traces -> GoTraceV1.lean -> Lean replay
+
+            ## Review Focus
+
+            ### CRITICAL (merge-blocking)
+            - sorry or admit in any proof (incomplete proof shipped as complete)
+            - Theorem statement that does not match spec semantics
+            - native_decide replaced with trivial (proves True, not the actual property)
+            - Universe inconsistencies or type errors masked by sorry
+            - Security-critical invariants weakened or removed
+
+            ### HIGH
+            - Missing edge cases in theorem coverage
+            - Proof that succeeds but proves weaker property than intended
+            - ByteArray/BEq proofs using simp without proper Array.isEqv bridge
+            - Conformance vector filtering errors (negative vectors in Lean = CI FAIL)
+
+            ### MEDIUM
+            - Proof style issues (overly complex tactics where simpler exist)
+            - Missing doc comments on public theorems
+            - Unused lemmas or dead code
+            - #eval blocks that should be native_decide theorems
+
+            ### LOW/INFO
+            - Naming convention drift from thm_<spec_section> pattern
+            - Import organization
+            - Proof coverage gaps (stated but not proved)
+
+            ## Lean 4 v4.6.0 Gotchas
+            - No Mathlib: convert, field_simp, ring unavailable. Use congr 1 + rw.
+            - Array.isEqv_self takes no function argument in this version
+            - List.getElem?_cons, Array.getElem?_push don't exist -- use simp [Array.push, Array.data]
+            - >>> vs Nat.shiftRight: use show to normalize before rw
+
+            ## Output Format
+
+            Post a review comment with:
+            1. Findings grouped by severity
+            2. For each: file, line, title, details, suggested fix
+            3. Proof completeness check: any sorry/admit?
+            4. Merge decision: SAFE TO MERGE / BLOCK ON PROOF GAP / BLOCK ON SPEC DRIFT
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Restrict claude-review to `.lean` file changes only (paths filter)
- Fix broken YAML: `model:` was misindented under `with:`, now uses `ANTHROPIC_MODEL` env var
- Pin `actions/checkout` to full SHA (v6)
- Expand review prompt with RUBIN-specific Lean 4 context: architecture, severity levels, v4.6.0 gotchas, proof completeness checks

## Test plan
- [ ] Workflow triggers only on PRs with .lean changes
- [ ] Review output includes Lean-specific findings