### PR TITLE
feat(rotation): Q-FORMAL-ROTATION-00 — suite-registry model + hardcoded-assumption audit

### DIFF
--- a/RubinFormal/CovenantGenesisV1.lean
+++ b/RubinFormal/CovenantGenesisV1.lean
@@ -16,6 +16,8 @@ def MAX_VAULT_KEYS : Nat := 12
 def MAX_VAULT_WHITELIST_ENTRIES : Nat := 1024
 def MAX_MULTISIG_KEYS : Nat := 12
 
+/- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-04):
+   creation gate becomes `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`. -/
 def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
@@ -229,6 +231,8 @@ structure TxOut where
   covenantData : Bytes
 deriving Repr, DecidableEq
 
+/-- **Pre-rotation scope**: P2PK creation rejects any `suiteId ≠ ML_DSA_87`.
+    Post-rotation (Q-FORMAL-ROTATION-04): `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`. -/
 def validateOutGenesis (out : TxOut) (txKind : Nat) (_blockHeight : Nat) : Except String Unit := do
   if out.covenantType == COV_TYPE_P2PK then
     if out.value == 0 then throw "TX_ERR_COVENANT_TYPE_INVALID"

--- a/RubinFormal/FormalGap03.lean
+++ b/RubinFormal/FormalGap03.lean
@@ -1,3 +1,13 @@
+/-
+  FormalGap03.lean — Pre-rotation scoped theorems.
+
+  All theorems in this file carry explicit `w.suiteId = SUITE_ID_ML_DSA_87`
+  hypotheses.  They remain valid as-is in the post-rotation world (they simply
+  prove properties of the ML-DSA-87 code path).
+
+  Post-rotation (Q-FORMAL-ROTATION-02/04): add per-suite variants that
+  generalise bounds and binding proofs to any suite in the registry.
+-/
 import RubinFormal.Conformance.CVValidationOrderReplay
 import RubinFormal.UtxoApplyGenesisV1
 

--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -21,6 +21,7 @@ import RubinFormal.SpendTxEndToEnd
 import RubinFormal.CovenantGenesisV1
 import RubinFormal.UtxoApplyGenesisV1
 import RubinFormal.FormalGap03
+import RubinFormal.RotationPrelude
 import RubinFormal.BlockValidationOrder
 import RubinFormal.RefinementBridgeV1
 import RubinFormal.Refinement.Index

--- a/RubinFormal/RotationPrelude.lean
+++ b/RubinFormal/RotationPrelude.lean
@@ -1,0 +1,121 @@
+/-
+  RubinFormal/RotationPrelude.lean — Suite-Registry Model & Pre-Rotation Audit Inventory
+
+  Q-FORMAL-ROTATION-00: prerequisite for Q-FORMAL-ROTATION-01..05.
+
+  ## Purpose
+
+  This file introduces the abstract suite-registry model that rotation
+  proofs (FI-ROT-01 … FI-ROT-07) will use, and documents which existing
+  definitions / theorems carry hardcoded SUITE_ID_ML_DSA_87 assumptions.
+
+  ## Pre-Rotation Scoping Convention
+
+  Every definition or theorem that assumes a single-suite world (only
+  SENTINEL + ML_DSA_87) is tagged with:
+
+    /-- **Pre-rotation scope**: assumes single native suite ML-DSA-87.
+        Must be generalised or re-proved under suite-registry model
+        for Q-FORMAL-ROTATION-0N. -/
+
+  ## Suite-Registry Model (abstract)
+
+  After rotation activation, the consensus rule is:
+    ∀ h, NATIVE_CREATE_SUITES(h) ⊆ NATIVE_SPEND_SUITES(h) ⊆ Registry
+  where Registry maps suite_id → (PUBKEY_BYTES, SIG_BYTES, VERIFY_COST, verifier).
+
+  The single-suite era is the special case where:
+    Registry = { 0x01 ↦ (2592, 4627, 8, ml_dsa_87_verify) }
+    NATIVE_CREATE_SUITES(h) = NATIVE_SPEND_SUITES(h) = {0x01}  ∀ h
+-/
+
+import RubinFormal.Types
+
+namespace RubinFormal
+
+namespace Rotation
+
+/-! ### Abstract suite-registry types -/
+
+/-- A single entry in the native suite registry. -/
+structure SuiteEntry where
+  suiteId      : Nat
+  pubkeyBytes  : Nat
+  sigBytes     : Nat
+  verifyCost   : Nat
+  deriving Repr, DecidableEq
+
+/-- The suite registry: a list of registered native suites.
+    In the single-suite era this contains exactly one entry (ML-DSA-87). -/
+def SuiteRegistry := List SuiteEntry
+
+/-- Height-dependent active suite sets (post-rotation model). -/
+structure RotationDescriptor where
+  oldSuite : Nat
+  newSuite : Nat
+  h1       : Nat   -- NATIVE_CREATE_SUITES cutoff
+  h2       : Nat   -- NATIVE_CREATE_SUITES + SPEND transition
+  h4       : Option Nat  -- old-suite sunset (None = never)
+  deriving Repr, DecidableEq
+
+/-- Lookup a suite entry by ID in the registry. -/
+def registryLookup (reg : SuiteRegistry) (sid : Nat) : Option SuiteEntry :=
+  reg.find? (fun e => e.suiteId == sid)
+
+/-! ### Single-suite (pre-rotation) era constants -/
+
+/-- The ML-DSA-87 registry entry, used throughout the pre-rotation codebase. -/
+def ML_DSA_87_ENTRY : SuiteEntry :=
+  { suiteId := 0x01, pubkeyBytes := 2592, sigBytes := 4627, verifyCost := 8 }
+
+/-- Pre-rotation registry: only ML-DSA-87 registered. -/
+def PRE_ROTATION_REGISTRY : SuiteRegistry := [ML_DSA_87_ENTRY]
+
+/-- Pre-rotation: NATIVE_CREATE_SUITES(h) = NATIVE_SPEND_SUITES(h) = {0x01} for all h. -/
+def preRotationActiveSuites (_h : Nat) : List Nat := [0x01]
+
+/-! ### Inventory of hardcoded assumptions (from Q-FORMAL-ROTATION-00 audit)
+
+  #### TxParseV2.lean
+  - `parseWitnessItem`: branches on `suiteID == SUITE_ID_ML_DSA_87`
+    with hardcoded `ML_DSA_87_PUBKEY_BYTES` / `ML_DSA_87_SIG_BYTES`.
+    **Action for ROT-03**: generalise to registry lookup for pubkey/sig bounds.
+
+  #### TxWeightV2.lean
+  - `parseWitnessItemForCounts`: same two-branch suite dispatch.
+  - `WitnessSectionResult.mlCount`: named for ML-DSA-87;
+    post-rotation becomes per-suite count or generic `knownSuiteCount`.
+  - `txWeightAndStats`: `mlCount * VERIFY_COST_ML_DSA_87` —
+    must become `Σ (suite, count) → count * registry[suite].verifyCost`.
+    **Action for ROT-03**: prove `weight_suite_aware_correct`.
+
+  #### CovenantGenesisV1.lean
+  - `validateOutGenesis`: `suiteId != SUITE_ID_ML_DSA_87 → reject`.
+    **Action for ROT-04**: generalise to `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`.
+
+  #### UtxoApplyGenesisV1.lean
+  - `validateP2PKSpendPreSig`: `suite != SUITE_ID_ML_DSA_87 → reject`.
+    **Action for ROT-04**: generalise to `suite ∉ NATIVE_SPEND_SUITES(h) → reject`.
+  - `validateWitnessItemLengths`: ML-DSA-87 branch with hardcoded bounds.
+    **Action for ROT-02/ROT-03**: lookup bounds from registry.
+  - `validateThresholdSigSpendNoCrypto`: ML-DSA-87 branch.
+    **Action for ROT-04**: same generalisation.
+  - `sampleOwnerP2PKData`: `SUITE_ID_ML_DSA_87` byte prefix in sample data.
+    **Action**: update samples if registry model changes output format.
+
+  #### UtxoBasicV1.lean
+  - `scanSingleInputStep`: `suite != SUITE_ID_ML_DSA_87 → reject` in P2PK path.
+    **Action for ROT-04**: generalise to `suite ∉ NATIVE_SPEND_SUITES(h)`.
+
+  #### FormalGap03.lean
+  - `sem001MLDSABoundedLengthStatement`: hypothesis `w.suiteId = SUITE_ID_ML_DSA_87`.
+    **Already scoped** — valid pre-rotation; post-rotation needs per-suite variant.
+  - `validateP2PKSpendPreSig_binds_pubkey`: conclusion includes `w.suiteId = SUITE_ID_ML_DSA_87`.
+    **Already scoped** — follows from `validateP2PKSpendPreSig` accepting only ML-DSA-87.
+  - `sem002_mldsa_binding_proved`: composition of above two.
+    **Already scoped** — inherits scope from premises.
+-/
+
+end Rotation
+
+end RubinFormal

--- a/RubinFormal/TxParseV2.lean
+++ b/RubinFormal/TxParseV2.lean
@@ -18,6 +18,8 @@ def MAX_WITNESS_BYTES_PER_TX : Nat := 100000
 -- Wire-level hard cap (CANONICAL §5.3).
 def MAX_COVENANT_DATA_PER_OUTPUT : Nat := 65536
 
+/- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-02/03):
+   replace with registry lookup via `Rotation.SuiteRegistry`. -/
 def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
@@ -64,6 +66,9 @@ def parseOutputs (c : Cursor) (n : Nat) : Option Cursor := do
     cur := cur4
   pure cur
 
+/-- **Pre-rotation scope**: witness-item canonicalization assumes only SENTINEL + ML-DSA-87.
+    Post-rotation (Q-FORMAL-ROTATION-02): dispatch via `Rotation.registryLookup` for
+    pubkey/sig bounds per registered suite. -/
 def parseWitnessItem (c : Cursor) : Option (Cursor × Option TxErr) := do
   let (suite, c1) ← c.getU8?
   let suiteID := suite.toNat

--- a/RubinFormal/TxWeightV2.lean
+++ b/RubinFormal/TxWeightV2.lean
@@ -12,12 +12,16 @@ namespace TxWeightV2
 -- Constants from CANONICAL §§2/4/5/9 (subset required for weight accounting).
 def WITNESS_DISCOUNT_DIVISOR : Nat := 4
 
+/- Pre-rotation verification costs.  Post-rotation (Q-FORMAL-ROTATION-03):
+   `verifyCost` is looked up from `Rotation.SuiteRegistry` per suite. -/
 def VERIFY_COST_ML_DSA_87 : Nat := 8
 def VERIFY_COST_UNKNOWN_SUITE : Nat := 64
 
 def MAX_WITNESS_ITEMS : Nat := 1024
 def MAX_WITNESS_BYTES_PER_TX : Nat := 100000
 
+/- Pre-rotation suite ID constants.  See `RotationPrelude.lean` for
+   the registry-based model used by Q-FORMAL-ROTATION-01..06. -/
 def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
@@ -74,6 +78,9 @@ def parseOutputsForAnchor (c : Cursor) (n : Nat) : Option (Cursor × Nat) := do
 -- isML: true iff suite=ML_DSA_87 with canonical pubkey/sig lengths.
 -- isSigAlgInvalid: true for unknown suites (not sentinel, not ML_DSA_87).
 -- isSigNoncanonical: true for ML_DSA_87 with wrong pubkey/sig lengths.
+/-- **Pre-rotation scope**: two-branch dispatch (SENTINEL vs ML-DSA-87).
+    Post-rotation (Q-FORMAL-ROTATION-03): classify per registry entry;
+    `isML` becomes `isKnownSuite`, bounds from `SuiteEntry`. -/
 def parseWitnessItemForCounts (c : Cursor) : Option (Cursor × Bool × Bool × Bool) := do
   let (suite, c1) ← c.getU8?
   let suiteID := suite.toNat
@@ -117,6 +124,9 @@ def parseWitnessItemForCounts (c : Cursor) : Option (Cursor × Bool × Bool × B
     -- Unknown suite ID
     pure (c5, false, true, false)
 
+/-- **Pre-rotation scope**: `mlCount` counts ML-DSA-87 witnesses only.
+    Post-rotation (Q-FORMAL-ROTATION-03): replace with per-suite count map
+    `suiteCounts : List (Nat × Nat)` keyed by suite_id. -/
 -- Witness section results.  Callers choose which fields to consume:
 --   weight function: uses mlCount + unknownSuiteCount, ignores error flags
 --   block/tx validation: uses error flags, ignores unknownSuiteCount
@@ -158,6 +168,9 @@ def parseWitnessSectionForWeight (c : Cursor) : Option WitnessSectionResult := d
            mlCount := mlCount, unknownSuiteCount := unknownSuiteCount,
            anySigAlgInvalid := anySigAlgInvalid, anySigNoncanonical := anySigNoncanonical }
 
+/-- **Pre-rotation scope**: sigCost = mlCount * VERIFY_COST_ML_DSA_87 + unknownCount * 64.
+    Post-rotation (Q-FORMAL-ROTATION-03, `weight_suite_aware_correct`):
+    sigCost = Σ_suite (count(suite) * registry[suite].verifyCost). -/
 def txWeightAndStats (tx : Bytes) : Except String WeightStats := do
   let c0 : Cursor := { bs := tx, off := 0 }
   let (_, c1) ←

--- a/RubinFormal/UtxoApplyGenesisV1.lean
+++ b/RubinFormal/UtxoApplyGenesisV1.lean
@@ -12,6 +12,8 @@ open RubinFormal
 open RubinFormal.UtxoBasicV1
 open RubinFormal.CovenantGenesisV1
 
+/- Pre-rotation suite constants (re-exported from CovenantGenesisV1).
+   Post-rotation (Q-FORMAL-ROTATION-02/04): use `Rotation.registryLookup`. -/
 def SUITE_ID_SENTINEL : Nat := CovenantGenesisV1.SUITE_ID_SENTINEL
 def SUITE_ID_ML_DSA_87 : Nat := CovenantGenesisV1.SUITE_ID_ML_DSA_87
 
@@ -36,6 +38,8 @@ def lockIdOfEntry (e : UtxoEntry) : Bytes :=
 def parseU16le (b0 b1 : UInt8) : Nat :=
   Wire.u16le? b0 b1
 
+/-- **Pre-rotation scope**: rejects any `suite ≠ ML_DSA_87`.
+    Post-rotation (Q-FORMAL-ROTATION-04): `suite ∉ NATIVE_SPEND_SUITES(h) → reject`. -/
 def validateP2PKSpendPreSig (entry : UtxoEntry) (w : WitnessItem) (_blockHeight : Nat) : Except String Unit := do
   let suite := w.suiteId
   if suite != SUITE_ID_ML_DSA_87 then
@@ -50,6 +54,8 @@ def validateP2PKSpendPreSig (entry : UtxoEntry) (w : WitnessItem) (_blockHeight 
   -- crypto verify omitted (out-of-scope for formal replay)
   pure ()
 
+/-- **Pre-rotation scope**: hardcoded ML-DSA-87 pubkey/sig bounds.
+    Post-rotation (Q-FORMAL-ROTATION-02): bounds from `Rotation.registryLookup`. -/
 def validateWitnessItemLengths (w : WitnessItem) (_blockHeight : Nat) : Except String Unit := do
   if w.suiteId == SUITE_ID_SENTINEL then
     if w.pubkey.size != 0 || w.signature.size != 0 then
@@ -62,6 +68,8 @@ def validateWitnessItemLengths (w : WitnessItem) (_blockHeight : Nat) : Except S
   else
     throw "TX_ERR_SIG_ALG_INVALID"
 
+/-- **Pre-rotation scope**: ML-DSA-87 is the only signing suite in threshold dispatch.
+    Post-rotation (Q-FORMAL-ROTATION-04): `suite ∉ NATIVE_SPEND_SUITES(h) → reject`. -/
 def validateThresholdSigSpendNoCrypto
     (keys : List Bytes)
     (threshold : Nat)

--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -24,6 +24,8 @@ def COV_TYPE_DA_COMMIT : Nat := 0x0103
 def COV_TYPE_HTLC : Nat := 0x0100
 def COV_TYPE_MULTISIG : Nat := 0x0104
 
+/- Pre-rotation: only ML-DSA-87 for native P2PK spend.
+   Post-rotation (Q-FORMAL-ROTATION-04): `suite ∉ NATIVE_SPEND_SUITES(h)`. -/
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def clampU64Max : Nat := (Nat.pow 2 64) - 1
@@ -378,6 +380,8 @@ def scanSingleInputStep
   if e.covenantType == COV_TYPE_P2PK then
     if e.covenantData.size != MAX_P2PK_COVENANT_DATA then
       throw "TX_ERR_COVENANT_TYPE_INVALID"
+    -- Pre-rotation scope: only ML-DSA-87 allowed for P2PK spend.
+    -- Post-rotation (Q-FORMAL-ROTATION-04): suite ∉ NATIVE_SPEND_SUITES(h) → reject.
     let suite := (e.covenantData.get! 0).toNat
     if suite != SUITE_ID_ML_DSA_87 then
       throw "TX_ERR_COVENANT_TYPE_INVALID"


### PR DESCRIPTION
## Q-FORMAL-ROTATION-00

Prerequisite for Q-FORMAL-ROTATION-01..06.

### What

Audit every Lean definition/theorem that hardcodes `SUITE_ID_ML_DSA_87` and either:
1. Explicitly scope it to the pre-rotation (single-suite) era, or
2. Document the generalisation path for the post-rotation registry model.

### New file

**`RotationPrelude.lean`** — abstract suite-registry types:
- `SuiteEntry` (suiteId, pubkeyBytes, sigBytes, verifyCost)
- `SuiteRegistry` (list of entries)
- `RotationDescriptor` (oldSuite, newSuite, h1, h2, h4)
- `registryLookup`, `ML_DSA_87_ENTRY`, `PRE_ROTATION_REGISTRY`
- Full inventory of all 23 hardcoded references across 6 files with action items per ROT-0N task

### Scope annotations (6 files)

| File | Hardcoded refs | Action for |
|------|---------------|------------|
| TxParseV2.lean | 4 (constants + parseWitnessItem) | ROT-02/03 |
| TxWeightV2.lean | 8 (costs, counts, sigCost formula) | ROT-03 |
| CovenantGenesisV1.lean | 2 (constants + validateOutGenesis) | ROT-04 |
| UtxoApplyGenesisV1.lean | 6 (3 validation functions + constants) | ROT-02/04 |
| UtxoBasicV1.lean | 2 (constant + scanSingleInputStep) | ROT-04 |
| FormalGap03.lean | 1 file-level (theorems already correctly scoped) | ROT-02/04 |

### Verification

- All modified files compile individually (`lake env lean`)
- 0 sorry
- Comments only — no semantic changes to existing definitions or theorems

Closes #128