### PR TITLE
fix(ci): rewrite DeepSeek security review — grep-based gate + improved prompt

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -135,19 +135,28 @@ jobs:
               issue_number: context.issue.number,
               body: `### Security Review: deepseek-v3\n_Model: deepseek/DeepSeek-V3-0324_\n\n\`\`\`json\n${review}\n\`\`\``
             });
-      - name: Hard block on sorry/admit in diff
+      - name: Hard block on sorry/admit in Lean files
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
             const diff = fs.readFileSync('pr-diff.txt', 'utf8');
-            const addedLines = diff.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'));
-            const sorryLines = addedLines.filter(l => {
-              const stripped = l.replace(/--.*$/, '');
-              return /\bsorry\b/.test(stripped) || /\badmit\b/.test(stripped);
-            });
+            // Split diff into per-file sections, only check .lean files
+            const sections = diff.split(/^diff --git /m).filter(s => s.includes('.lean'));
+            const sorryLines = [];
+            for (const section of sections) {
+              const lines = section.split('\n');
+              for (const line of lines) {
+                if (!line.startsWith('+') || line.startsWith('+++')) continue;
+                // Strip Lean line comments
+                const stripped = line.replace(/--.*$/, '');
+                if (/\bsorry\b/.test(stripped) || /\badmit\b/.test(stripped)) {
+                  sorryLines.push(line);
+                }
+              }
+            }
             if (sorryLines.length > 0) {
-              core.setFailed(`Merge blocked: sorry/admit found in added lines:\n${sorryLines.join('\n')}`);
+              core.setFailed(`Merge blocked: sorry/admit in .lean files:\n${sorryLines.join('\n')}`);
             } else {
-              core.info('No sorry/admit in added lines — passed');
+              core.info('No sorry/admit in .lean added lines — passed');
             }


### PR DESCRIPTION
## Problem

DeepSeek hallucinated CRITICAL findings on every PR regardless of prompt:
- "axiom replaced with theorem" → marked CRITICAL (this is an improvement)
- "private lemmas not visible in diff" → CRITICAL (they ARE in the diff)
- Prompt changes had no effect — model ignores severity instructions

## Fix (two changes)

### 1. Merge gate: grep for sorry/admit (replaces LLM judgment)
Old: DeepSeek says CRITICAL → block merge
New: `grep -w sorry/admit` in added lines → block merge

LLM-based severity is unreliable for merge-blocking decisions. Hard grep catches the only thing that matters: unsound proofs with sorry/admit.

### 2. Prompt rewritten
- Russian language, tight constraints
- Explicit FORBIDDEN list (improvements, style, doc comments)
- Empty findings = good
- DeepSeek review stays as informational comment, does not block

## Why separate PR
GitHub Actions uses workflow from **base branch** for pull_request events. Workflow changes in a PR branch dont take effect for that PR. This must merge to main first, then the Lean PR can use the updated workflow.