### PR TITLE
formal: sync multi-source section hash coverage

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "524435b419d9bd5853d4a7f73d71961bf061a2b778f13303e429bc1de55ad35a",
+  "spec_section_hashes_sha3_256": "e65824e8882c5c29b76430fe9783838caa0a4101f3874fffa028f60701b388c7",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [
@@ -196,7 +196,7 @@
     },
     {
       "section_key": "replay_domain_checks",
-      "section_heading": "## 17. Replay-Domain Checks (Normative)",
+      "section_heading": "## 1. Replay-Domain Checks (Normative)",
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_replay_vectors_pass"
@@ -205,7 +205,7 @@
     },
     {
       "section_key": "utxo_state_model",
-      "section_heading": "## 18. UTXO State Model (Normative)",
+      "section_heading": "## 2. UTXO State Model (Normative)",
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_utxo_basic_vectors_pass",


### PR DESCRIPTION
Summary:
- sync proof_coverage.json to the new multi-source SECTION_HASHES.json digest
- retarget replay/utxo pinned headings to RUBIN_CONSENSUS_STATE_MACHINE.md sections

Context:
- required downstream for rubin-spec state-machine extraction batch
- keeps formal disposition aligned with updated integrity scope

Refs:
- Q-SPEC-BOUNDARY-01
- Q-SPEC-CONSENSUS-STATE-MACHINE-01
- Q-SPEC-CONSENSUS-STATE-MACHINE-04