### PR TITLE
chore: sync proof coverage section hash

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "a63ae948ca8f710ff98d2203f8dff3319c4e90784e51404a7a3948677d81e1e1",
+  "spec_section_hashes_sha3_256": "c41e8cc55471ad7b4a1816e27798a0dc236e80a8c5eab4642efe2463c3a9a112",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [


### PR DESCRIPTION
## Summary
- sync `proof_coverage.json` with current `rubin-spec-private/spec/SECTION_HASHES.json`
- unblock rubin-spec PR#203 validate job

## Queue
- Q-FORMAL-CORE-EXT-SECTION-HASH-ALIGN-01

## Validation
- python3 -m json.tool proof_coverage.json >/dev/null