### PR TITLE
formal: sync proof coverage for core ext state machine

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "49caa52222f04dda636d28b677d30680b4d47e2d1a4fcc326efb7bf170e9c4ee",
+  "spec_section_hashes_sha3_256": "f442b73983a7e6e2769c3f6d6c2f4a302720be5b505be4f48bac47a38093d594",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [


### PR DESCRIPTION
Refs: Q-FORMAL-CORE-EXT-SECTION-HASH-ALIGN-01

## Summary
- refresh proof_coverage.json for the updated pinned SECTION_HASHES.json
- keep formal disposition aligned with the CORE_EXT state-machine and conformance-gate clarification in spec PR #203

## Validation
- hash-only metadata sync; no Lean proof semantics changed
