### PR TITLE
formal: add da_set_integrity to refinement_bridge.json

### DIFF
--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -46,6 +46,19 @@
       "model_theorem": "RubinFormal.value_conservation_proved",
       "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "evidence_level": "baseline"
+    },
+    {
+      "op": "da_set_integrity",
+      "gate": "CV-DA",
+      "model_theorem": "RubinFormal.da_set_integrity_proved",
+      "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "theorem_file": "rubin-formal/RubinFormal/DaIntegrityV1.lean",
+      "evidence_level": "baseline",
+      "spec_section": "§21",
+      "go_function": "validateDASetIntegrity",
+      "limitations": [
+        "Proves non-emptiness invariant (empty chunk set is invalid). Does not cover the full DA validation pipeline including chunk hashing and manifest verification."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add missing `da_set_integrity` entry to `refinement_bridge.json` critical_ops
- Maps Go `validateDASetIntegrity` (§21) → Lean `da_set_integrity_proved` theorem
- Closes machine-readable traceability gap between proof coverage and bridge registry

## Evidence
- `da_set_integrity_proved` already proved in `PinnedSections.lean:270`
- Backed by `DaIntegrityV1.lean` (chunk-set non-emptiness invariant)
- JSON validated, `lake build` clean

Closes #167
Refs: Q-FORMAL-DA-INTEGRITY-BRIDGE-01