### PR TITLE
formal: upgrade consensus_constants and sighash_v1 to proved

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -11,7 +11,7 @@
     {
       "section_key": "consensus_constants",
       "section_heading": "## 4. Consensus Constants (Wire-Level)",
-      "status": "stated",
+      "status": "proved",
       "theorems": [
         "RubinFormal.sem001_mldsa_bounded_lengths_proved",
         "RubinFormal.subsidy_u128_safety_proved",
@@ -103,7 +103,7 @@
     {
       "section_key": "sighash_v1",
       "section_heading": "## 12. Sighash v1 (Normative)",
-      "status": "stated",
+      "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_sighash_vectors_pass",
         "RubinFormal.digestV1_deterministic",


### PR DESCRIPTION
## Summary
- Upgrade `consensus_constants` (§4) status from `stated` → `proved` in proof_coverage.json
- Upgrade `sighash_v1` (§12) status from `stated` → `proved` in proof_coverage.json
- All 3 constants theorems + 16 sighash theorems are already fully proved (zero sorry)
- This is a metadata-only change reflecting the actual proof state

## Theorems verified
### §4 Consensus Constants (3)
- `sem001_mldsa_bounded_lengths_proved` (FormalGap03.lean)
- `subsidy_u128_safety_proved` (PinnedSections.lean)
- `htlc_timelock_proved` (PinnedSections.lean)

### §12 Sighash v1 (16)
- `cv_sighash_vectors_pass` (conformance replay)
- `digestV1_deterministic`, `buildPreimageFrameParts_injective`
- 6x `selectHash*` coverage theorems
- 5x `buildPreimageFrameParts_commits_*` structural theorems

Closes #169
Refs: Q-FORMAL-CONSTANTS-SIGHASH-PROVED-01