### PR TITLE
fix: stop overclaiming txcontext gate coverage

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -381,7 +381,7 @@
     {
       "section_key": "txcontext_formal",
       "section_heading": "## SPEC-TXCTX-01 \u00a714. TxContext Pre-Activation Gates",
-      "status": "proved",
+      "status": "stated",
       "theorems": [
         "RubinFormal.TxContext.uint128GTE_correct",
         "RubinFormal.TxContext.uint128GTE_native_equivalence",
@@ -406,9 +406,9 @@
         "RubinFormal.TxContext.parallel_error_equivalence": "rubin-formal/RubinFormal/TxContextFormal.lean",
         "RubinFormal.TxContext.sighash_policy_complete": "rubin-formal/RubinFormal/TxContextFormal.lean"
       },
-      "notes": "SPEC-TXCTX-01 \u00a714 pre-activation gate theorems. All eight required theorems proven: uint128GTE correctness and native equivalence, ext_id sort determinism, n_total empty v2, k-overflow discard completeness, vault conservation no double-count, parallel error equivalence, sighash policy completeness.",
+      "notes": "SPEC-TXCTX-01 \u00a714 pre-activation gate theorems. Several subclaims are mechanized, but the section is not counted as proved coverage because k_overflow_discard_complete remains a structural theorem over a simplified ADT rather than the concrete BuildTxContext model required for the activation gate.",
       "limitations": [
-        "extid_sort_deterministic proves functional determinism (same input = same output) and concrete CV-51/CV-84 regression vectors; full multiset permutation uniqueness deferred to Mathlib dependency.",
+        "extid_sort_deterministic now proves the output is a sorted permutation of the input, but the section remains non-gating until every required activation theorem is tied to the concrete model.",
         "parallel_error_equivalence relies on purity of evaluation function; does not model OS-level thread scheduling.",
         "k_overflow_discard_complete is structural (ADT has no partial state on err); does not model implementation-level memory."
       ]


### PR DESCRIPTION
### Motivation
- The SPEC-TXCTX-01 §14 coverage entry claimed `proved` despite one remaining weak/vacuous mechanization (`k_overflow_discard_complete` is structural over a simplified `BuildResult` ADT), creating a false-assurance activation gating risk. 
- The change prevents activation decisions from relying on overstated coverage while leaving substantive theorem work to be completed against the concrete `BuildTxContext` model.

### Description
- Downgrade the `txcontext_formal` coverage entry status from `proved` to `stated` in `proof_coverage.json` to reflect the remaining modeling gap. 
- Update the `notes` and `limitations` text for the `txcontext_formal` section to document that `k_overflow_discard_complete` is structural over a simplified ADT and that the section is not yet activation-gating. 
- No Lean theorem source code was modified; this is a metadata/coverage remediation to avoid false claims of gating proof coverage.

### Testing
- Validated JSON syntax with `python -m json.tool proof_coverage.json` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/format errors, which returned no problems. 
- Did not attempt `lake build`/Lean compilation in this environment because the Lean toolchain was unavailable, so theorem recompilation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe7167cc483228cafa30bc5c7947b)