### PR TITLE
fix: correct post-cutoff rotation conformance vectors

### DIFF
--- a/RubinFormal/Conformance/CVNativeRotationCutoffVectors.lean
+++ b/RubinFormal/Conformance/CVNativeRotationCutoffVectors.lean
@@ -13,7 +13,7 @@ structure CVNativeRotationCutoffVector where
 
 def cvNativeRotationCutoffVectors : List CVNativeRotationCutoffVector := [
   { id := "NATIVE-ROT-CUTOFF-01", op := "rotation_create_suite_check", height := 199, suiteId := 1, expectOk := true, expectErr := none },
-  { id := "NATIVE-ROT-CUTOFF-02", op := "rotation_create_suite_check", height := 200, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-CUTOFF-02", op := "rotation_create_suite_check", height := 200, suiteId := 1, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
   { id := "NATIVE-ROT-CUTOFF-03", op := "rotation_create_suite_check", height := 200, suiteId := 2, expectOk := true, expectErr := none },
   { id := "NATIVE-ROT-CUTOFF-04", op := "rotation_create_suite_check", height := 99, suiteId := 2, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
   { id := "NATIVE-ROT-CUTOFF-05", op := "rotation_create_suite_check", height := 100, suiteId := 2, expectOk := true, expectErr := none },

--- a/RubinFormal/Conformance/CVNativeRotationSunsetVectors.lean
+++ b/RubinFormal/Conformance/CVNativeRotationSunsetVectors.lean
@@ -14,9 +14,9 @@ structure CVNativeRotationSunsetVector where
 def cvNativeRotationSunsetVectors : List CVNativeRotationSunsetVector := [
   { id := "NATIVE-ROT-SUNSET-01", op := "rotation_spend_suite_check", height := 399, suiteId := 1, expectOk := true, expectErr := none },
   { id := "NATIVE-ROT-SUNSET-02", op := "rotation_spend_suite_check", height := 400, suiteId := 1, expectOk := true, expectErr := none },
-  { id := "NATIVE-ROT-SUNSET-03", op := "rotation_create_suite_check", height := 399, suiteId := 1, expectOk := true, expectErr := none },
+  { id := "NATIVE-ROT-SUNSET-03", op := "rotation_create_suite_check", height := 399, suiteId := 1, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
   { id := "NATIVE-ROT-SUNSET-04", op := "rotation_create_suite_check", height := 400, suiteId := 1, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" },
-  { id := "NATIVE-ROT-SUNSET-05", op := "rotation_create_suite_check", height := 999999, suiteId := 1, expectOk := true, expectErr := none }
+  { id := "NATIVE-ROT-SUNSET-05", op := "rotation_create_suite_check", height := 999999, suiteId := 1, expectOk := false, expectErr := some "TX_ERR_SIG_ALG_INVALID" }
 ]
 
 end RubinFormal.Conformance


### PR DESCRIPTION
### Motivation
- Conformance vectors incorrectly marked the old suite as create-eligible at and after the `h2` cutoff, contradicting the formal `NativeCreateSuites` phase transition and the proved invariant `fi_rot_05_old_suite_rejected_after_h2` that requires old-suite create to reject for all `h ≥ h2`.
- If left uncorrected, replay of these vectors could normalize invalid consensus behavior and mask regressions in create-gate enforcement.

### Description
- Updated `RubinFormal/Conformance/CVNativeRotationCutoffVectors.lean` to change `NATIVE-ROT-CUTOFF-02` (height 200, `suiteId := 1`) to expect rejection with `TX_ERR_SIG_ALG_INVALID` instead of acceptance.
- Updated `RubinFormal/Conformance/CVNativeRotationSunsetVectors.lean` to change `NATIVE-ROT-SUNSET-03` (height 399) and `NATIVE-ROT-SUNSET-05` (height 999999) to expect rejection with `TX_ERR_SIG_ALG_INVALID` instead of acceptance.
- Preserved vector IDs, counts, and surrounding replay structure and did not change any Lean proofs or production code implementing the rotation gate semantics.

### Testing
- Ran `git diff --check` which produced no whitespace or diff errors and succeeded.
- Ran a repository scan for placeholder artifacts with `rg -n "sorry|admit|todo!|unimplemented!|panic!"` which found no new placeholders in the touched area and succeeded.
- Attempted `lake build` to run Lean builds but it failed to execute because `lake` is not installed in the environment, so full proof/build validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe82d53b483228725f21c46cd87bb)