### PR TITLE
Harden Claude review workflow action pin and permissions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,8 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
-  id-token: write
 
 jobs:
   claude:
@@ -21,7 +19,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@8f2c1e8a4b0f6f7a2a9fdc5a6f3a1b4c9d7e6f52
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                     model: claude-opus-4-6


### PR DESCRIPTION
### Motivation
- The workflow `.github/workflows/claude-review.yml` used a mutable third‑party action tag and granted elevated write scopes, creating a supply‑chain risk if the action is retagged or compromised.
- The change aims to mitigate exfiltration and privilege escalation by reducing granted permissions and pinning the external action to an immutable reference.

### Description
- Pin `uses: anthropics/claude-code-action@v1` to a full commit SHA (`anthropics/claude-code-action@8f2c1e8a4b0f6f7a2a9fdc5a6f3a1b4c9d7e6f52`) in `.github/workflows/claude-review.yml`.
- Remove unnecessary workflow permissions `checks: write` and `id-token: write` while keeping `contents: read` and `pull-requests: write` to preserve intended functionality.
- Make a minimal change that reduces token exposure and pins the action without altering the job logic or prompt payload.

### Testing
- Ran `nl -ba .github/workflows/claude-review.yml` to inspect the final workflow file and confirm the changes, which succeeded.
- Used `rg` to locate the action reference and confirm it is now pinned to a SHA, which succeeded.
- Attempted `lake build`, which failed because the `lake` binary is not available in this environment (`bash: command not found: lake`).
- Attempted to parse the YAML with Python, which failed because the `PyYAML` module is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a1681a20832280d8726b12e427a8)