### PR TITLE
fix: prevent vacuous pass for retarget go-trace bridge

### DIFF
--- a/RubinFormal/Refinement/GoTraceV1Check.lean
+++ b/RubinFormal/Refinement/GoTraceV1Check.lean
@@ -118,7 +118,8 @@ private def checkPow (o : PowOut) : Bool :=
         false
 
 def retargetGoTraceV1Pass : Bool :=
-  (powOuts.filter (fun o => o.op == "retarget_v1")).all checkPow
+  let retargetRows := powOuts.filter (fun o => o.op == "retarget_v1")
+  !retargetRows.isEmpty && retargetRows.all checkPow
 
 private def toUtxoPairs? (us : List RubinFormal.Conformance.CVUtxoEntry) : Option (List (Outpoint × UtxoEntry)) :=
   us.mapM (fun u => do


### PR DESCRIPTION
### Motivation
- Prevent a vacuous proof path where `retargetGoTraceV1Pass` could evaluate to `true` when there are zero `retarget_v1` rows in the Go trace corpus, which allowed the bridge to claim `machine_checked_contract` without actual trace coverage.

### Description
- Update `RubinFormal/Refinement/GoTraceV1Check.lean` to bind the filtered rows and require non-empty coverage by changing `retargetGoTraceV1Pass` to `let retargetRows := powOuts.filter (fun o => o.op == "retarget_v1")` and return `!retargetRows.isEmpty && retargetRows.all checkPow` so the check is only true when at least one `retarget_v1` row is present and every such row passes `checkPow`.

### Testing
- Attempted to run the project's build with `lake build` but it could not be executed in this environment because `lake` is not installed (`bash: command not found: lake`). No other automated tests were available or run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f5140d008322883f80d833dd8291)