### PR TITLE
fix: tighten admit placeholder gate

### DIFF
--- a/RubinFormal/Conformance/CVCompactReplay.lean
+++ b/RubinFormal/Conformance/CVCompactReplay.lean
@@ -273,11 +273,11 @@ def evalCompact (v : CVCompactVector) : (Bool × Option String) :=
   else if v.op == "compact_orphan_limits" then
     match v.currentPeerBytes, v.currentDaIdBytes, v.currentGlobalBytes, v.incomingChunkBytes, v.expectAdmit with
     | some peerB, some daB, some globB, some inB, some expAdmit =>
-        let admit :=
+        let admitted :=
           orphanAdmit peerB inB 4194304 &&
           orphanAdmit daB inB 8388608 &&
           orphanAdmit globB inB 67108864
-        let ok := admit == expAdmit
+        let ok := admitted == expAdmit
         (ok, if ok then none else some "TX_ERR_PARSE")
     | _, _, _, _, _ => (false, some "TX_ERR_PARSE")
   else if v.op == "compact_sendcmpct_modes" then
@@ -340,9 +340,9 @@ def evalCompact (v : CVCompactVector) : (Bool × Option String) :=
     | some cur, some lim, some _inc, some hasCommit, some rsr, some mins, some expStorm, some expAdmit, some expRb =>
         let fillPct := (cur * 100) / lim
         let storm := fillPct >= 90
-        let admit := (!storm) || hasCommit
+        let admitted := (!storm) || hasCommit
         let rollback := storm && hasCommit && (rsr < 95) && (mins >= 10)
-        let ok := (storm == expStorm) && (admit == expAdmit) && (rollback == expRb)
+        let ok := (storm == expStorm) && (admitted == expAdmit) && (rollback == expRb)
         (ok, if ok then none else some "TX_ERR_PARSE")
     | _, _, _, _, _, _, _, _, _ => (false, some "TX_ERR_PARSE")
   else if v.op == "compact_eviction_tiebreak" then
@@ -386,8 +386,8 @@ def evalCompact (v : CVCompactVector) : (Bool × Option String) :=
           v.expectCountedBytes, v.expectIgnoredOverheadBytes, v.expectAdmit with
     | some cap, some cur, some incPayload, some incOver, some expCounted, some expIgnored, some expAdmit =>
         let counted := cur + incPayload
-        let admit := counted <= cap
-        let ok := (counted == expCounted) && (incOver == expIgnored) && (admit == expAdmit)
+        let admitted := counted <= cap
+        let ok := (counted == expCounted) && (incOver == expIgnored) && (admitted == expAdmit)
         (ok, if ok then none else some "TX_ERR_PARSE")
     | _, _, _, _, _, _, _ => (false, some "TX_ERR_PARSE")
   else if v.op == "compact_storm_commit_bearing" then
@@ -397,8 +397,8 @@ def evalCompact (v : CVCompactVector) : (Bool × Option String) :=
         let storm := stormMode fill trig
         let cb := isCommitBearing c1 c2 c3
         let prio := storm && cb
-        let admit := (!storm) || cb
-        let ok := storm == expStorm && cb == expCb && prio == expPrio && admit == expAdmit
+        let admitted := (!storm) || cb
+        let ok := storm == expStorm && cb == expCb && prio == expPrio && admitted == expAdmit
         (ok, if ok then none else some "TX_ERR_PARSE")
     | _, _, _, _, _, _, _, _, _ => (false, some "TX_ERR_PARSE")
   else if v.op == "compact_chunk_count_cap" then


### PR DESCRIPTION
### Motivation
- The CI placeholder scan only matched a few specific `admit` forms and could be bypassed by parenthesized or embedded uses such as `have h := (admit : T)`, undermining proof-integrity gating.
- The change hardens the gate to detect any standalone `admit` token after stripping comments/strings while avoiding noisy false-positives in Lean code.

### Description
- Replace the list of specific admit regexes in `.github/workflows/ci.yml` with a single standalone-token regex `ADMIT_RE = re.compile(r"(?<![A-Za-z0-9_'])admit(?![A-Za-z0-9_'])")` and use it to flag admits after comment/string stripping.
- Rename local boolean bindings named `admit` to `admitted` in `RubinFormal/Conformance/CVCompactReplay.lean` and update the corresponding equality checks so the new CI token scan does not incorrectly flag ordinary identifiers.
- Preserve the existing comment/string stripping logic and overall scan flow so the gate continues to ignore admits inside comments/strings.

### Testing
- Ran the updated placeholder-scan Python logic against the repository `RubinFormal/**/*.lean` and it reported `Lean placeholder scan passed` (no admits found in source after the change). 
- Reproduced the original bypass by creating a temporary PoC Lean file with `have h := (admit : True)` and verified the updated scan reports the admit placeholder for that file. 
- Attempted to run `lake build` to validate Lean build but the container lacked `lake`/`elan`, so the build step was not executed (tooling missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe82e96788322b824986175555ed5)