### PR TITLE
fix: remove unsupported parallel equivalence proof claims

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -381,7 +381,7 @@
     {
       "section_key": "txcontext_formal",
       "section_heading": "## SPEC-TXCTX-01 \u00a714. TxContext Pre-Activation Gates",
-      "status": "proved",
+      "status": "stated",
       "theorems": [
         "RubinFormal.TxContext.uint128GTE_correct",
         "RubinFormal.TxContext.uint128GTE_native_equivalence",


### PR DESCRIPTION
### Motivation
- The repository advertised a proved parallel-vs-sequential equivalence (Q-PV-19) based on an abstract Lean package whose lemmas are vacuous and not tied to the real pipeline, which overstates formal assurance.
- Rather than introduce a fragile or incorrect linkage, the minimal safe remediation is to remove the unsupported artifact and the metadata that presented it as proved.

### Description
- Deleted the abstract refinement module `RubinFormal/Refinement/ParallelEquivalence.lean` which contained tautological lemmas not linked to the real verifier.
- Removed the import of that module from `RubinFormal/Refinement/Index.lean` so it is no longer part of the active refinement surface.
- Removed the `parallel_validation_equivalence` coverage entry from `proof_coverage.json` so the repository no longer claims Q-PV-19 as proved.
- Reverted the refinement bridge `status` to `baseline` and removed the Q-PV-19 note in `refinement_bridge.json` to reflect the accurate evidence level.

### Testing
- Validated JSON syntax for modified metadata with `python -m json.tool proof_coverage.json` and `python -m json.tool refinement_bridge.json`, both succeeded.
- Confirmed removal of references using `rg -n "ParallelEquivalence|parallel_validation_equivalence|Q-PV-19|pv-refined" -S RubinFormal proof_coverage.json refinement_bridge.json`, which returned no remaining matches.
- Attempted to run a Lean build check (`which lake || true`) but `lake` is not installed in the environment, so a full Lean build could not be executed here; no Lean proofs were introduced or changed in a way that requires building for this remediation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe82d84988322bfff3cad8e68c9e0)