### PR TITLE
fix: include sighashType in preimage parts injectivity proof

### DIFF
--- a/RubinFormal/SighashV1.lean
+++ b/RubinFormal/SighashV1.lean
@@ -264,9 +264,9 @@ theorem buildPreimageFrameParts_injective (a b : SighashPreimageFrame)
     (hEq : buildPreimageFrameParts a = buildPreimageFrameParts b) :
     a = b := by
   cases a with
-  | mk aChainId aVersionLE aTxKind aTxNonceLE aHashDA aHashPrevouts aHashSeq aInputIndexLE aPrevTxid aPrevVoutLE aInputValueLE aSequenceLE aHashOutputs aLocktimeLE =>
+  | mk aChainId aVersionLE aTxKind aTxNonceLE aHashDA aHashPrevouts aHashSeq aInputIndexLE aPrevTxid aPrevVoutLE aInputValueLE aSequenceLE aHashOutputs aLocktimeLE aSighashType =>
     cases b with
-    | mk bChainId bVersionLE bTxKind bTxNonceLE bHashDA bHashPrevouts bHashSeq bInputIndexLE bPrevTxid bPrevVoutLE bInputValueLE bSequenceLE bHashOutputs bLocktimeLE =>
+    | mk bChainId bVersionLE bTxKind bTxNonceLE bHashDA bHashPrevouts bHashSeq bInputIndexLE bPrevTxid bPrevVoutLE bInputValueLE bSequenceLE bHashOutputs bLocktimeLE bSighashType =>
       simp [buildPreimageFrameParts, RubinFormal.bytes] at hEq ⊢
       simpa using hEq
 


### PR DESCRIPTION
### Motivation
- `SighashPreimageFrame` was extended with a new `sighashType` field but `buildPreimageFrameParts_injective` still pattern-matched the old constructor shape, leaving the new field unbound and breaking the injectivity argument (and potentially the build). 

### Description
- Update the `cases ... | mk ...` patterns in `buildPreimageFrameParts_injective` to bind `aSighashType` and `bSighashType`, restoring constructor-arity alignment with `buildPreimageFrameParts` without changing the existing proof steps; the change is in `RubinFormal/SighashV1.lean`.

### Testing
- Attempted to run `lake build` and `lean --version` to validate the change, but both could not be executed in this environment because the Lean toolchain is not installed, so no compile-time tests were run; the change is syntactic and preserves the original `simp`/`simpa` proof sequence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4971fcc3c8322af021bef159fb944)