### PR TITLE
fix(ci): pin remaining workflow actions

### DIFF
--- a/.github/workflows/claude-oauth.yml
+++ b/.github/workflows/claude-oauth.yml
@@ -15,7 +15,7 @@ jobs:
   auth:
     runs-on: ubuntu-latest
     steps:
-      - uses: grll/claude-code-login@v1
+      - uses: grll/claude-code-login@3c519b71d608864c85b4d98b802a326bfb835cb2
         with:
           code: ${{ inputs.code }}
           secrets_admin_pat: ${{ secrets.SECRETS_ADMIN_PAT }}

--- a/.github/workflows/formal-hygiene.yml
+++ b/.github/workflows/formal-hygiene.yml
@@ -14,12 +14,12 @@ jobs:
   premise-smell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Check for premise smells in Lean theorems
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { execSync } = require('child_process');


### PR DESCRIPTION
Pins the remaining unpinned workflow actions in `claude-oauth.yml` and `formal-hygiene.yml` without changing PAT usage or workflow behavior.