### PR TITLE
formal: UTXO SpendTx behavioral state-transition proofs (§18)

### DIFF
--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -35,3 +35,4 @@ import RubinFormal.CoreExtRefinement
 import RubinFormal.TxContextFormal
 import RubinFormal.ForkChoiceTiebreak
 import RubinFormal.ErrorPriority
+import RubinFormal.UtxoSpendTxBehavioral

--- a/RubinFormal/UtxoSpendTxBehavioral.lean
+++ b/RubinFormal/UtxoSpendTxBehavioral.lean
@@ -1,0 +1,73 @@
+import RubinFormal.ConnectBlockStrong
+import RubinFormal.SpendTxEndToEnd
+
+/-!
+# UTXO SpendTx Behavioral Proof (§18)
+
+Connects the existing strong theorem surfaces (ConnectBlockStrong,
+SpendTxEndToEnd) into a unified behavioral statement about SpendTx
+state transitions over the real UTXO-map model.
+
+Main result: `spendTx_behavioral` — if `applyNonCoinbaseTxBasicState`
+succeeds, then:
+1. All inputs were available in the UTXO map
+2. No intra-tx double spend occurred
+3. Value conservation holds (sum_in >= sum_out + fee)
+4. The output UTXO map is the prepared `nextUtxoMap`
+-/
+
+namespace RubinFormal
+
+open RubinFormal.UtxoBasicV1
+open RubinFormal.SubsidyV1
+
+/-- Full behavioral statement for a single SpendTx state transition.
+    Combines input availability, no-double-spend, value conservation,
+    and deterministic UTXO-map output into one theorem. -/
+theorem spendTx_behavioral
+    (txBytes : Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (fee : Nat)
+    (nextMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (hApply :
+      applyNonCoinbaseTxBasicState txBytes utxoMap height blockTimestamp chainId = .ok (fee, nextMap)) :
+    ∃ prepared,
+      prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId = .ok prepared ∧
+      prepared.fee = fee ∧
+      prepared.nextUtxoMap = nextMap ∧
+      inputs_available prepared.tx utxoMap height ∧
+      no_intra_tx_double_spend prepared.tx ∧
+      utxo_conserved_tx prepared.tx utxoMap height prepared.fee := by
+  rcases applyNonCoinbaseTxBasicState_success_prepared
+      txBytes utxoMap height blockTimestamp chainId fee nextMap hApply with
+    ⟨prepared, hPrep, hFee, hNext⟩
+  refine ⟨prepared, hPrep, hFee, hNext, ?_, ?_, ?_⟩
+  · exact prepareNonCoinbaseTxBasic_inputs_available
+      txBytes utxoMap height blockTimestamp chainId prepared hPrep
+  · exact prepareNonCoinbaseTxBasic_no_intra_double_spend
+      txBytes utxoMap height blockTimestamp chainId prepared hPrep
+  · exact prepareNonCoinbaseTxBasic_utxo_conserved
+      txBytes utxoMap height blockTimestamp chainId prepared hPrep
+
+/-- Block-level behavioral statement: `connectBlockTxs` over a list of
+    transactions preserves UTXO conservation AND no-double-spend for
+    every transaction in the list. Directly reuses the inductive proof
+    from ConnectBlockStrong. -/
+theorem connectBlockTxs_behavioral
+    (txs : List Bytes)
+    (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (height blockTimestamp : Nat)
+    (chainId : Bytes)
+    (sumFees : Nat)
+    (finalMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
+    (hConnect :
+      connectBlockTxs txs utxoMap height blockTimestamp chainId = .ok (sumFees, finalMap)) :
+    utxo_conserved txs utxoMap height blockTimestamp chainId ∧
+    no_double_spend txs utxoMap height blockTimestamp chainId := by
+  constructor
+  · exact utxo_conservation_theorem txs utxoMap height blockTimestamp chainId sumFees finalMap hConnect
+  · exact no_double_spend_theorem txs utxoMap height blockTimestamp chainId sumFees finalMap hConnect
+
+end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -267,7 +267,9 @@
         "RubinFormal.utxo_conservation_theorem",
         "RubinFormal.no_double_spend_theorem",
         "RubinFormal.chainConsistency_inductive",
-        "RubinFormal.spendTx_end_to_end"
+        "RubinFormal.spendTx_end_to_end",
+        "RubinFormal.spendTx_behavioral",
+        "RubinFormal.connectBlockTxs_behavioral"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -289,9 +291,11 @@
         "RubinFormal.utxo_conservation_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.no_double_spend_theorem": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
         "RubinFormal.chainConsistency_inductive": "rubin-formal/RubinFormal/ConnectBlockStrong.lean",
-        "RubinFormal.spendTx_end_to_end": "rubin-formal/RubinFormal/SpendTxEndToEnd.lean"
+        "RubinFormal.spendTx_end_to_end": "rubin-formal/RubinFormal/SpendTxEndToEnd.lean",
+        "RubinFormal.spendTx_behavioral": "rubin-formal/RubinFormal/UtxoSpendTxBehavioral.lean",
+        "RubinFormal.connectBlockTxs_behavioral": "rubin-formal/RubinFormal/UtxoSpendTxBehavioral.lean"
       },
-      "notes": "Section now includes the substantive behavioral theorem surfaces from ConnectBlockStrong.lean and SpendTxEndToEnd.lean. These prove UTXO conservation (sum_in >= sum_out + fee), no intra-tx double spend, inductive chain consistency, and end-to-end SpendTx correctness over the real prepareNonCoinbaseTxBasic function. Status remains 'stated' because the broader UTXO state model (TXCTX construction, ext_id ordering, rollback/discard) is not yet fully proved.",
+      "notes": "Section now includes single-tx behavioral proof (spendTx_behavioral: inputs_available + no_double_spend + conservation + deterministic nextUtxoMap) and block-level composition (connectBlockTxs_behavioral: conservation + no_double_spend across all txs). Status remains stated because TXCTX/coinbase/vault paths not fully proved.",
       "limitations": [
         "No theorem in the current registry proves SpendTx step 3c TxContext construction or the exact bundle contents for TxContext-enabled CORE_EXT spends.",
         "No theorem in the current registry proves the >K continuing-output reject / discard semantics or the ext_id ordering rule added by TXCTX.",


### PR DESCRIPTION
Single-tx + block-level behavioral proofs reusing ConnectBlockStrong/SpendTxEndToEnd.

Refs: Q-FORMAL-UTXO-SPENDTX-BEHAVIORAL-01
Related: #183, #190