### PR TITLE
formal: structural rules behavioral proofs (§16)

### DIFF
--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -38,3 +38,4 @@ import RubinFormal.ErrorPriority
 import RubinFormal.UtxoSpendTxBehavioral
 import RubinFormal.WeightBehavioral
 import RubinFormal.RetargetBehavioral
+import RubinFormal.StructuralRulesBehavioral

--- a/RubinFormal/StructuralRulesBehavioral.lean
+++ b/RubinFormal/StructuralRulesBehavioral.lean
@@ -1,0 +1,29 @@
+import RubinFormal.UtxoApplyGenesisV1
+
+/-!
+# Transaction Structural Rules Behavioral Proofs (§16)
+
+Proves behavioral properties of structural transaction validators.
+-/
+
+namespace RubinFormal
+
+open UtxoApplyGenesisV1
+open UtxoBasicV1
+
+/-- Concrete: unknown suite ID 0x05 is rejected with TX_ERR_SIG_ALG_INVALID. -/
+theorem unknown_suite_0x05_rejected :
+    validateWitnessItemLengths ⟨0x05, ByteArray.empty, ByteArray.empty⟩ 0 =
+    .error "TX_ERR_SIG_ALG_INVALID" := by rfl
+
+/-- Concrete: sentinel with non-empty pubkey is rejected. -/
+theorem sentinel_nonempty_pubkey_rejected :
+    validateWitnessItemLengths ⟨SUITE_ID_SENTINEL, ⟨#[0x01]⟩, ByteArray.empty⟩ 0 =
+    .error "TX_ERR_PARSE" := by rfl
+
+/-- Concrete: sentinel with empty pubkey+sig is accepted. -/
+theorem sentinel_empty_accepted :
+    validateWitnessItemLengths ⟨SUITE_ID_SENTINEL, ByteArray.empty, ByteArray.empty⟩ 0 =
+    .ok () := by rfl
+
+end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -260,13 +260,23 @@
       "theorems": [
         "RubinFormal.Conformance.cv_validation_order_vectors_pass",
         "RubinFormal.core_ext_cursor_no_ambiguity_proved",
-        "RubinFormal.sem002_mldsa_binding_proved"
+        "RubinFormal.sem002_mldsa_binding_proved",
+        "RubinFormal.unknown_suite_0x05_rejected",
+        "RubinFormal.sentinel_nonempty_pubkey_rejected",
+        "RubinFormal.sentinel_empty_accepted"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.sem002_mldsa_binding_proved": "rubin-formal/RubinFormal/FormalGap03.lean",
-        "RubinFormal.core_ext_cursor_no_ambiguity_proved": "rubin-formal/RubinFormal/PinnedSections.lean"
-      }
+        "RubinFormal.core_ext_cursor_no_ambiguity_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
+        "RubinFormal.unknown_suite_0x05_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.sentinel_nonempty_pubkey_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.sentinel_empty_accepted": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean"
+      },
+      "notes": "Structural validation proved through concrete witness-item behavioral tests: unknown suite rejection, sentinel empty enforcement, sentinel nonempty rejection. Combined with existing cursor-no-ambiguity and ML-DSA binding proofs.",
+      "limitations": [
+        "Universal quantified witness structural theorem not proved — concrete test cases only due to do-notation unfolding complexity."
+      ]
     },
     {
       "section_key": "replay_domain_checks",


### PR DESCRIPTION
Concrete witness-item validation tests proved by rfl.

Refs: Q-FORMAL-STRUCTURAL-RULES-BEHAVIORAL-01
Related: #190