### PR TITLE
ci: harden DeepSeek formal review against stale and vacuous findings

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
       - name: Download diff artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
@@ -63,7 +65,7 @@ jobs:
             const baseSha = '${{ github.event.pull_request.base.sha }}';
             const headSha = '${{ github.event.pull_request.head.sha }}';
             const changedLeanFiles = execSync(
-              `git diff --name-only ${baseSha} ${headSha} -- '*.lean'`,
+              `git diff --diff-filter=ACMR --name-only ${baseSha} ${headSha} -- '*.lean'`,
               { maxBuffer: 20 * 1024 * 1024 }
             )
               .toString()


### PR DESCRIPTION
Refs: Q-FORMAL-DEEPSEEK-REVIEW-HARDENING-01

Issue: #230

This narrows the DeepSeek formal review workflow by:
- feeding current changed Lean file contents plus PR title/body, not diff only
- teaching the model to prefer low-FP behavior and catch vacuous/overclaimed formal proofs
- filtering stale, off-file, and duplicate findings before posting the bot comment

Validation:
- YAML parse: PASS
