### PR TITLE
fix: remove last tautological theorem

### DIFF
--- a/RubinFormal/TransactionWireBehavioral.lean
+++ b/RubinFormal/TransactionWireBehavioral.lean
@@ -4,8 +4,6 @@ import RubinFormal.TxParseV2
 # Transaction Wire Behavioral Proofs (§5)
 
 Proves behavioral properties of the ByteWireV2 transaction parser.
-ParseResult is a flat structure (ok:Bool, err, txid, wtxid), not
-an inductive, so pattern matching requires field access.
 -/
 
 namespace RubinFormal
@@ -20,10 +18,6 @@ theorem parseTx_empty_rejected :
 theorem parseTx_short_rejected :
     (parseTx (ByteArray.mk #[0x01, 0x00])).ok = false := by rfl
 
-/-- parseTx is deterministic: same input always produces same ParseResult. -/
-theorem parseTx_deterministic (tx : Bytes) :
-    parseTx tx = parseTx tx := rfl
-
 /-- Single-byte input is rejected. -/
 theorem parseTx_single_byte_rejected :
     (parseTx (ByteArray.mk #[0xFF])).ok = false := by rfl
@@ -31,5 +25,8 @@ theorem parseTx_single_byte_rejected :
 /-- Three-byte input (still too short for version) is rejected. -/
 theorem parseTx_three_bytes_rejected :
     (parseTx (ByteArray.mk #[0x01, 0x00, 0x00])).ok = false := by rfl
+
+-- parseTx determinism is trivially true for all pure Lean functions
+-- (f x = f x by rfl). Not included as a theorem — it's a language property.
 
 end RubinFormal


### PR DESCRIPTION
Remove parseTx_deterministic (f x = f x := rfl). Language property, not meaningful theorem.