### PR TITLE
ci: raise claude review max turns

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 10
+            --max-turns 64
           prompt: |
             You are the first-pass formal reviewer for RUBIN Lean PRs.
 


### PR DESCRIPTION
## Summary
- raise the Claude Code review turn limit for formal review
- keep the Opus 4.6 v1 configuration path unchanged
- repair the live max-turn exhaustion seen after PR #246

## Testing
- python3 - <<'PY'\nimport yaml, pathlib\npath = pathlib.Path(".github/workflows/claude-review.yml")\nyaml.safe_load(path.read_text())\nprint("YAML OK")\nPY\n- git diff --check\n\nQ-ID: Q-CI-CLAUDE-REVIEW-V1-OPUS46-CROSSREPO-01