### PR TITLE
formal: close txcontext continuing outputs bound

### DIFF
--- a/RubinFormal/ConnectBlockFull.lean
+++ b/RubinFormal/ConnectBlockFull.lean
@@ -40,7 +40,7 @@ structure TxContextInputData where
     will later be packed into the computed TxContext. This avoids validating
     detached metadata. -/
 def continuingCountsFromData (continuingData : List (Nat × TxContextContinuing)) : List Nat :=
-  continuingData.map fun pair => pair.2.count
+  continuingData.map fun pair => pair.2.outputs.length
 
 /-- Extract the actual sighash byte from a witness item.
     Empty signatures fail before the policy gate runs. -/

--- a/RubinFormal/TxContextBehavioral.lean
+++ b/RubinFormal/TxContextBehavioral.lean
@@ -26,11 +26,13 @@ structure TxOutputView where
   value : Nat
   extPayload : List UInt8
 
-/-- Per-ext_id continuing output bundle with bounded count. -/
+/-- Per-ext_id continuing output bundle with bounded metadata count and
+    bounded carried outputs. -/
 structure TxContextContinuing where
   count : Nat
   outputs : List TxOutputView
   hBound : count ≤ TXCONTEXT_MAX_CONTINUING_OUTPUTS
+  hOutputsBound : outputs.length ≤ TXCONTEXT_MAX_CONTINUING_OUTPUTS
 
 /-- TxContext base — immutable transaction-level context. -/
 structure TxContextBase where
@@ -261,6 +263,10 @@ theorem buildTxContextFromValues_height_real
 theorem continuing_bound_is_invariant (cont : TxContextContinuing) :
     cont.count ≤ TXCONTEXT_MAX_CONTINUING_OUTPUTS := cont.hBound
 
+/-- Every TxContextContinuing carries outputs.length ≤ MAX as TYPE INVARIANT. -/
+theorem continuing_outputs_length_is_invariant (cont : TxContextContinuing) :
+    cont.outputs.length ≤ TXCONTEXT_MAX_CONTINUING_OUTPUTS := cont.hOutputsBound
+
 /-- MAX = 2 (canonical constant from §14). -/
 theorem max_continuing_is_two : TXCONTEXT_MAX_CONTINUING_OUTPUTS = 2 := rfl
 
@@ -275,6 +281,19 @@ theorem buildTxContext_all_continuings_bounded
     pair.2.count ≤ 2 := by
   have hCd := buildTxContext_continuing_data ids hLen tin tout ht cd bundle hEq
   rw [hCd] at hMem; exact pair.2.hBound
+
+/-- ALL continuings in a built bundle carry at most 2 actual outputs. -/
+theorem buildTxContext_all_continuings_outputs_bounded
+    (ids : List Nat) (hLen : ids.length > 0)
+    (tin tout ht : Nat) (cd : List (Nat × TxContextContinuing))
+    (bundle : TxContextBundle)
+    (hEq : buildTxContext ids tin tout ht cd = some bundle)
+    (pair : Nat × TxContextContinuing)
+    (hMem : pair ∈ bundle.continuingByExt) :
+    pair.2.outputs.length ≤ 2 := by
+  have hCd := buildTxContext_continuing_data ids hLen tin tout ht cd bundle hEq
+  rw [hCd] at hMem
+  exact pair.2.hOutputsBound
 
 /-! ## Cross-property: value conservation (fee ≥ 0) -/
 

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -956,6 +956,8 @@
         "RubinFormal.buildTxContext_ext_ids",
         "RubinFormal.compareUint128_native_equivalence",
         "RubinFormal.continuing_output_count_rejects_overflow",
+        "RubinFormal.continuing_outputs_length_is_invariant",
+        "RubinFormal.buildTxContext_all_continuings_outputs_bounded",
         "RubinFormal.vault_bridge_no_vault",
         "RubinFormal.vault_bridge_with_vault",
         "RubinFormal.SighashV1.checkSighashPolicy_exhaustive_256x256",
@@ -967,12 +969,14 @@
         "RubinFormal.buildTxContext_ext_ids": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
         "RubinFormal.compareUint128_native_equivalence": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
         "RubinFormal.continuing_output_count_rejects_overflow": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
+        "RubinFormal.continuing_outputs_length_is_invariant": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
+        "RubinFormal.buildTxContext_all_continuings_outputs_bounded": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
         "RubinFormal.vault_bridge_no_vault": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
         "RubinFormal.vault_bridge_with_vault": "rubin-formal/RubinFormal/TxContextBehavioral.lean",
         "RubinFormal.SighashV1.checkSighashPolicy_exhaustive_256x256": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.checkSighashPolicy_invalid_base_rejected": "rubin-formal/RubinFormal/SighashV1.lean"
       },
-      "notes": "§14 pre-activation gate closure on the live Lean helper/computed TxContext surface. 8 closure theorems: ext_id ordering is wired into buildTxContext/buildTxContextLive via sortExtIds, Uint128 comparison is closed by live compareUint128, K-overflow is closed by the live validateContinuingOutputCount reject path, vault conservation is bridged to live validateValueConservation, and sighash policy is closed exhaustively in SighashV1 over 256×256. The computed block helper derives continuing counts from the same continuingData it packs and extracts the sighash byte from a witness item instead of detached metadata. The legacy aggregate connectBlockFull wrapper remains compatibility surface and is not itself counted as the live gate path. TxContextFormal remains the model/support surface; the proved row no longer relies on wrapper-only bridge claims. Parallel error index work remains auxiliary in Refinement.ParallelEquivalence and is not counted toward §14 closure.",
+      "notes": "§14 pre-activation gate closure on the live Lean helper/computed TxContext surface. 10 closure theorems: ext_id ordering is wired into buildTxContext/buildTxContextLive via sortExtIds, Uint128 comparison is closed by live compareUint128, K-overflow is closed by the live validateContinuingOutputCount reject path, the carried continuing outputs list itself is bounded both at the TxContextContinuing type and at the built-bundle surface, vault conservation is bridged to live validateValueConservation, and sighash policy is closed exhaustively in SighashV1 over 256×256. The computed block helper derives continuing counts from the actual carried outputs inside the same continuingData bundle and extracts the sighash byte from a witness item instead of detached metadata. The legacy aggregate connectBlockFull wrapper remains compatibility surface and is not itself counted as the live gate path. TxContextFormal remains the model/support surface; the proved row no longer relies on wrapper-only bridge claims. Parallel error index work remains auxiliary in Refinement.ParallelEquivalence and is not counted toward §14 closure.",
       "limitations": []
     }
   ],


### PR DESCRIPTION
Refs: Q-FORMAL-TXCONTEXT-CONTINUING-LENGTH-01

## Summary
- add a real invariant that bounds `TxContextContinuing.outputs.length`
- validate computed continuing counts from the actual carried outputs list
- record the new closure theorems in `proof_coverage.json` without widening scope

## Validation
- `python3 -m json.tool proof_coverage.json >/dev/null`
- `export PATH="$HOME/.elan/bin:$PATH" && lake build RubinFormal.TxContextBehavioral RubinFormal.ConnectBlockFull`