### PR TITLE
fix: canonicalize SUITE_ID_SENTINEL to single definition in Types.lean

### DIFF
--- a/RubinFormal/CoreExtInvariants.lean
+++ b/RubinFormal/CoreExtInvariants.lean
@@ -1,4 +1,5 @@
 import Std
+import RubinFormal.Types
 
 namespace RubinFormal
 
@@ -15,8 +16,6 @@ v2 (Q-FORMAL-GAP-01, F-04 fix, 2026-03-06):
 - `coreExtTighteningStatement` in PinnedSections now includes the rejection property.
 -/
 
-/-- CORE_EXT suite ID constants (CANONICAL §5.4). -/
-def SUITE_ID_SENTINEL : Nat := 0x00
 
 structure WitnessItemMini where
   suiteId : Nat

--- a/RubinFormal/CovenantGenesisV1.lean
+++ b/RubinFormal/CovenantGenesisV1.lean
@@ -8,6 +8,10 @@ open Wire
 
 namespace CovenantGenesisV1
 
+/-- Namespace alias to canonical RubinFormal.SUITE_ID_SENTINEL (see #284). -/
+abbrev SUITE_ID_SENTINEL : Nat := RubinFormal.SUITE_ID_SENTINEL
+abbrev SUITE_ID_ML_DSA_87 : Nat := RubinFormal.SUITE_ID_ML_DSA_87
+
 def MAX_P2PK_COVENANT_DATA : Nat := 33
 def MAX_ANCHOR_PAYLOAD_SIZE : Nat := 65536
 def MAX_HTLC_COVENANT_DATA : Nat := 105
@@ -15,11 +19,6 @@ def MAX_HTLC_COVENANT_DATA : Nat := 105
 def MAX_VAULT_KEYS : Nat := 12
 def MAX_VAULT_WHITELIST_ENTRIES : Nat := 1024
 def MAX_MULTISIG_KEYS : Nat := 12
-
-/- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-04):
-   creation gate becomes `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
-def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def COV_TYPE_P2PK : Nat := 0x0000
 def COV_TYPE_ANCHOR : Nat := 0x0002

--- a/RubinFormal/FormalGap03.lean
+++ b/RubinFormal/FormalGap03.lean
@@ -73,7 +73,7 @@ theorem det001_validation_order_proved : det001ValidationOrderStatement := by
 
 theorem sem001_mldsa_bounded_lengths_proved : sem001MLDSABoundedLengthStatement := by
   intro w blockHeight hSuite
-  have hDistinct : ¬CovenantGenesisV1.SUITE_ID_ML_DSA_87 = CovenantGenesisV1.SUITE_ID_SENTINEL := by
+  have hDistinct : ¬RubinFormal.SUITE_ID_ML_DSA_87 = RubinFormal.SUITE_ID_SENTINEL := by
     native_decide
   by_cases hPub : w.pubkey.size = UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES
   · by_cases hSig0 : w.signature.size = 0

--- a/RubinFormal/NativeSuiteRotation.lean
+++ b/RubinFormal/NativeSuiteRotation.lean
@@ -24,6 +24,9 @@ namespace NativeSuiteRotation
 
 open Rotation
 
+/-- Namespace alias to canonical RubinFormal.SUITE_ID_SENTINEL (see #284). -/
+abbrev SUITE_ID_SENTINEL : Nat := RubinFormal.SUITE_ID_SENTINEL
+
 /-! ### Rotation Deployment Descriptor (extended from RotationPrelude) -/
 
 /-- A full rotation deployment descriptor with all lifecycle heights. -/
@@ -34,9 +37,6 @@ structure RotationDeploymentDescriptor where
   h2         : Nat   -- old suite create-ineligible
   h4         : Option Nat  -- old suite spend-ineligible (sunset); None = never
   deriving Repr, DecidableEq
-
-/-- SUITE_ID_SENTINEL constant (0x00) — sentinel is never a valid active suite. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
 
 /-- A descriptor is well-formed per CANONICAL §4.1.3:
     - old ≠ new

--- a/RubinFormal/StructuralRulesBehavioral.lean
+++ b/RubinFormal/StructuralRulesBehavioral.lean
@@ -51,12 +51,12 @@ theorem unknown_suite_rejected_universal
     (hNotM : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_SIG_ALG_INVALID" := by
   have hS : w.suiteId ≠ 0 := by
-    simp [UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at hNotS; exact hNotS
+    simp [UtxoApplyGenesisV1.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_SENTINEL] at hNotS; exact hNotS
   have hM : w.suiteId ≠ 1 := by
-    simp [UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at hNotM; exact hNotM
+    simp [UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, RubinFormal.SUITE_ID_ML_DSA_87] at hNotM; exact hNotM
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87]
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87]
   simp [hS, hM]; rfl
 
 /-! ## R2: Sentinel — non-empty pubkey or sig rejected -/
@@ -69,7 +69,7 @@ theorem sentinel_nonempty_rejected_universal
     (hNE : w.pubkey.size ≠ 0 ∨ w.signature.size ≠ 0) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_PARSE" := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at *
+    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_SENTINEL] at *
   simp only [hS, beq_self_eq_true, ite_true]
   rcases hNE with hp | hs
   · simp [bne_iff_ne, hp, Bool.true_or]; rfl
@@ -86,7 +86,7 @@ theorem sentinel_empty_accepted_universal
     (hSE : w.signature.size = 0) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at *
+    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_SENTINEL] at *
   simp only [hS, beq_self_eq_true, ite_true]
   simp [bne_iff_ne, hPE, hSE]; rfl
 
@@ -102,7 +102,7 @@ theorem mldsa87_wrong_pubkey_rejected_universal
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hBad, Bool.true_or]; rfl
 
 /-! ## R5: ML-DSA-87 — sig bounds rejected -/
@@ -118,7 +118,7 @@ theorem mldsa87_empty_sig_rejected_universal
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hPOk, hSig0]; rfl
 
 /-- **R5b (universal):** ML-DSA-87 with sig too large is rejected.
@@ -132,7 +132,7 @@ theorem mldsa87_sig_too_large_rejected_universal
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM]
   split
   · rfl
@@ -153,7 +153,7 @@ theorem mldsa87_valid_accepted_universal
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hPOk,
         show w.signature.size ≠ 0 from by omega]
   simp [show ¬(4628 < w.signature.size) from by omega]; rfl
@@ -187,7 +187,7 @@ theorem threshold_unknown_suite_head_rejected
     .error "TX_ERR_SIG_ALG_INVALID" := by
   simp only [UtxoApplyGenesisV1.validateThresholdSigSpendNoCrypto,
     UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, RubinFormal.SUITE_ID_ML_DSA_87] at *
   have hLen' : wrest.length = krest.length := by simp [List.length] at hLen; omega
   simp [hLen', hNotS, hNotM]
   show Except.error "TX_ERR_SIG_ALG_INVALID" = Except.error "TX_ERR_SIG_ALG_INVALID"; rfl

--- a/RubinFormal/TxParseV2.lean
+++ b/RubinFormal/TxParseV2.lean
@@ -9,6 +9,10 @@ open Wire
 
 namespace TxV2
 
+/-- Namespace alias to canonical RubinFormal.SUITE_ID_SENTINEL (see #284). -/
+abbrev SUITE_ID_SENTINEL : Nat := RubinFormal.SUITE_ID_SENTINEL
+abbrev SUITE_ID_ML_DSA_87 : Nat := RubinFormal.SUITE_ID_ML_DSA_87
+
 -- Consensus constants (subset, from CANONICAL §2/§5).
 def MAX_TX_INPUTS : Nat := 1024
 def MAX_TX_OUTPUTS : Nat := 1024
@@ -17,11 +21,6 @@ def MAX_WITNESS_ITEMS : Nat := 1024
 def MAX_WITNESS_BYTES_PER_TX : Nat := 100000
 -- Wire-level hard cap (CANONICAL §5.3).
 def MAX_COVENANT_DATA_PER_OUTPUT : Nat := 65536
-
-/- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-02/03):
-   replace with registry lookup via `Rotation.SuiteRegistry`. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
-def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
 def ML_DSA_87_SIG_BYTES : Nat := 4627

--- a/RubinFormal/TxWeightV2.lean
+++ b/RubinFormal/TxWeightV2.lean
@@ -9,6 +9,10 @@ open Wire
 
 namespace TxWeightV2
 
+/-- Namespace alias to canonical RubinFormal.SUITE_ID_SENTINEL (see #284). -/
+abbrev SUITE_ID_SENTINEL : Nat := RubinFormal.SUITE_ID_SENTINEL
+abbrev SUITE_ID_ML_DSA_87 : Nat := RubinFormal.SUITE_ID_ML_DSA_87
+
 -- Constants from CANONICAL §§2/4/5/9 (subset required for weight accounting).
 def WITNESS_DISCOUNT_DIVISOR : Nat := 4
 
@@ -19,11 +23,6 @@ def VERIFY_COST_UNKNOWN_SUITE : Nat := 64
 
 def MAX_WITNESS_ITEMS : Nat := 1024
 def MAX_WITNESS_BYTES_PER_TX : Nat := 100000
-
-/- Pre-rotation suite ID constants.  See `RotationPrelude.lean` for
-   the registry-based model used by Q-FORMAL-ROTATION-01..06. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
-def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
 def ML_DSA_87_SIG_BYTES : Nat := 4627

--- a/RubinFormal/Types.lean
+++ b/RubinFormal/Types.lean
@@ -33,4 +33,11 @@ instance : Repr Bytes where
 instance : Inhabited Bytes where
   default := ByteArray.empty
 
+
+/-- Canonical suite ID constants (CANONICAL §2.3 / §5.4).
+    All modules MUST reference these definitions instead of
+    defining local copies.  See issue #284. -/
+def SUITE_ID_SENTINEL : Nat := 0x00
+def SUITE_ID_ML_DSA_87 : Nat := 0x01
+
 end RubinFormal

--- a/RubinFormal/UtxoApplyGenesisV1.lean
+++ b/RubinFormal/UtxoApplyGenesisV1.lean
@@ -12,10 +12,10 @@ open RubinFormal
 open RubinFormal.UtxoBasicV1
 open RubinFormal.CovenantGenesisV1
 
-/- Pre-rotation suite constants (re-exported from CovenantGenesisV1).
+/- Pre-rotation suite constants (re-exported from RubinFormal.Types canonical).
    Post-rotation (Q-FORMAL-ROTATION-02/04): use `Rotation.registryLookup`. -/
-def SUITE_ID_SENTINEL : Nat := CovenantGenesisV1.SUITE_ID_SENTINEL
-def SUITE_ID_ML_DSA_87 : Nat := CovenantGenesisV1.SUITE_ID_ML_DSA_87
+def SUITE_ID_SENTINEL : Nat := RubinFormal.SUITE_ID_SENTINEL
+def SUITE_ID_ML_DSA_87 : Nat := RubinFormal.SUITE_ID_ML_DSA_87
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
 def ML_DSA_87_SIG_BYTES : Nat := 4627

--- a/RubinFormal/WeightSuiteAware.lean
+++ b/RubinFormal/WeightSuiteAware.lean
@@ -63,7 +63,7 @@ private theorem suiteAwareCost_nonSentinel (reg : SuiteRegistry) (sid : Nat)
     suiteAwareCost reg sid = match registryLookup reg sid with
       | some entry => entry.verifyCost
       | none => TxWeightV2.VERIFY_COST_UNKNOWN_SUITE := by
-  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL
+  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL RubinFormal.SUITE_ID_SENTINEL
   have hbeq : (sid == (0 : Nat)) = false := by
     show Nat.beq sid 0 = false
     exact nat_beq_ne_zero h
@@ -95,7 +95,7 @@ theorem fi_rot_03_total_sig_cost_deterministic
 /-- Sentinel suite has zero cost. -/
 theorem fi_rot_03_sentinel_zero_cost (reg : SuiteRegistry) :
     suiteAwareCost reg TxWeightV2.SUITE_ID_SENTINEL = 0 := by
-  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL
+  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL RubinFormal.SUITE_ID_SENTINEL
   simp
 
 /-- ML-DSA-87 cost matches hardcoded VERIFY_COST_ML_DSA_87 in pre-rotation registry. -/


### PR DESCRIPTION
## Summary

- Move `SUITE_ID_SENTINEL` and `SUITE_ID_ML_DSA_87` to `RubinFormal.Types` as single canonical `def`
- Replace 4 independent `def` copies (CovenantGenesisV1, TxV2, TxWeightV2, NativeSuiteRotation) + 1 in CoreExtInvariants with `abbrev` namespace aliases
- Update proof tactics in StructuralRulesBehavioral, FormalGap03, WeightSuiteAware to unfold through alias chain
- 10 files changed, +39/-36

## Motivation

Hostile formal audit (F-104, P0): five independent `def SUITE_ID_SENTINEL : Nat := 0x00` in different namespaces. If any one is changed independently, proofs that cross namespace boundaries silently break or produce inconsistent results.

## Verification

- `lake build`: 348/348 modules, 0 errors
- All existing theorems pass unchanged (only tactic unfold paths adjusted)
- No semantic change: all aliases resolve to the same `0x00` / `0x01` values

Closes #284