### PR TITLE
formal: harden rotation descriptor and canonicalize sentinel

### DIFF
--- a/RubinFormal/ConsensusConstantsBehavioral.lean
+++ b/RubinFormal/ConsensusConstantsBehavioral.lean
@@ -40,7 +40,7 @@ theorem witness_mldsa_bounds_violated_rejects (w : WI) (h : Nat)
     UtxoApplyGenesisV1.validateWitnessItemLengths w h =
     .error "TX_ERR_SIG_NONCANONICAL" := by
   unfold UtxoApplyGenesisV1.validateWitnessItemLengths; rw [hSuite]
-  rw [show (ML_DSA == UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = false from by native_decide]
+  rw [show (ML_DSA == RubinFormal.SUITE_ID_SENTINEL) = false from by native_decide]
   simp only [ite_false]
   rw [show (ML_DSA == ML_DSA) = true from by native_decide]; simp only [ite_true]
   simp only [hBad, ite_true]; rfl
@@ -52,7 +52,7 @@ theorem witness_mldsa_bounds_satisfied_accepts (w : WI) (h : Nat)
             w.signature.size > SIG_BYTES + 1) = false) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   unfold UtxoApplyGenesisV1.validateWitnessItemLengths; rw [hSuite]
-  rw [show (ML_DSA == UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = false from by native_decide]
+  rw [show (ML_DSA == RubinFormal.SUITE_ID_SENTINEL) = false from by native_decide]
   simp only [ite_false]
   rw [show (ML_DSA == ML_DSA) = true from by native_decide]; simp only [ite_true]
   simp only [hOk, ite_false]; rfl
@@ -66,7 +66,7 @@ explicit-bind version and prove rfl equivalence. -/
 /-- Explicit-bind version of validateWitnessItemLengths.
     rfl-equivalent to the LIVE do-block version. -/
 private def validateWitnessExplicit (w : WI) (_h : Nat) : Except String Unit :=
-  if w.suiteId == UtxoApplyGenesisV1.SUITE_ID_SENTINEL then
+  if w.suiteId == RubinFormal.SUITE_ID_SENTINEL then
     if (w.pubkey.size != 0) || (w.signature.size != 0) then
       Except.error "TX_ERR_PARSE"
     else Except.ok ()
@@ -88,7 +88,7 @@ theorem validateWitnessItemLengths_eq_explicit (w : WI) (h : Nat) :
 
 /-- Suite not SENTINEL and not ML_DSA → rejected with SIG_ALG_INVALID. -/
 theorem witness_unknown_suite_rejects (w : WI) (h : Nat)
-    (hNotSent : (w.suiteId == UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = false)
+    (hNotSent : (w.suiteId == RubinFormal.SUITE_ID_SENTINEL) = false)
     (hNotMldsa : (w.suiteId == ML_DSA) = false) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h =
     .error "TX_ERR_SIG_ALG_INVALID" := by
@@ -99,23 +99,23 @@ theorem witness_unknown_suite_rejects (w : WI) (h : Nat)
 
 /-- Sentinel with non-empty pubkey or sig → rejected with TX_ERR_PARSE. -/
 theorem witness_sentinel_nonempty_rejects (w : WI) (h : Nat)
-    (hSuite : w.suiteId = UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hSuite : w.suiteId = RubinFormal.SUITE_ID_SENTINEL)
     (hBad : ((w.pubkey.size != 0) || (w.signature.size != 0)) = true) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h =
     .error "TX_ERR_PARSE" := by
   unfold UtxoApplyGenesisV1.validateWitnessItemLengths; rw [hSuite]
-  rw [show (UtxoApplyGenesisV1.SUITE_ID_SENTINEL ==
-           UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = true from by native_decide]
+  rw [show (RubinFormal.SUITE_ID_SENTINEL ==
+           RubinFormal.SUITE_ID_SENTINEL) = true from by native_decide]
   simp only [ite_true, hBad]; rfl
 
 /-- Valid sentinel → accepted. -/
 theorem witness_sentinel_valid_accepts (w : WI) (h : Nat)
-    (hSuite : w.suiteId = UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hSuite : w.suiteId = RubinFormal.SUITE_ID_SENTINEL)
     (hOk : ((w.pubkey.size != 0) || (w.signature.size != 0)) = false) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   unfold UtxoApplyGenesisV1.validateWitnessItemLengths; rw [hSuite]
-  rw [show (UtxoApplyGenesisV1.SUITE_ID_SENTINEL ==
-           UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = true from by native_decide]
+  rw [show (RubinFormal.SUITE_ID_SENTINEL ==
+           RubinFormal.SUITE_ID_SENTINEL) = true from by native_decide]
   simp only [ite_true, hOk, ite_false]; rfl
 
 /-! ## Exhaustive suite coverage (LIVE)
@@ -137,14 +137,14 @@ theorem witness_validation_exhaustive (w : WI) (h : Nat) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   rw [validateWitnessItemLengths_eq_explicit]
   simp only [validateWitnessExplicit]
-  by_cases hSent : (w.suiteId == UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = true
+  by_cases hSent : (w.suiteId == RubinFormal.SUITE_ID_SENTINEL) = true
   · simp only [hSent, ite_true]
     by_cases hBad : ((w.pubkey.size != 0) || (w.signature.size != 0)) = true
     · simp only [hBad, ite_true]; exact Or.inl trivial -- TX_ERR_PARSE
     · have : ((w.pubkey.size != 0) || (w.signature.size != 0)) = false :=
         Bool.eq_false_iff.mpr (fun h => by rw [h] at hBad; exact hBad rfl)
       simp only [this, ite_false]; exact Or.inr (Or.inr (Or.inr trivial)) -- .ok ()
-  · have hSF : (w.suiteId == UtxoApplyGenesisV1.SUITE_ID_SENTINEL) = false :=
+  · have hSF : (w.suiteId == RubinFormal.SUITE_ID_SENTINEL) = false :=
       Bool.eq_false_iff.mpr (fun h => by rw [h] at hSent; exact hSent rfl)
     simp only [hSF, ite_false]
     by_cases hMl : (w.suiteId == ML_DSA) = true

--- a/RubinFormal/CoreExtInvariants.lean
+++ b/RubinFormal/CoreExtInvariants.lean
@@ -1,4 +1,5 @@
 import Std
+import RubinFormal.Types
 
 namespace RubinFormal
 
@@ -15,9 +16,6 @@ v2 (Q-FORMAL-GAP-01, F-04 fix, 2026-03-06):
 - `coreExtTighteningStatement` in PinnedSections now includes the rejection property.
 -/
 
-/-- CORE_EXT suite ID constants (CANONICAL §5.4). -/
-def SUITE_ID_SENTINEL : Nat := 0x00
-
 structure WitnessItemMini where
   suiteId : Nat
 deriving DecidableEq
@@ -31,7 +29,7 @@ def coreExtLegacyAllowed (_w : WitnessItemMini) : Prop :=
 /-- Post-activation semantics: witness item's suiteId must be in the allowed set
     AND must not be the SENTINEL (0x00, which means anyone-can-spend). -/
 def coreExtActiveAllowed (allowedSuiteIds : List Nat) (w : WitnessItemMini) : Prop :=
-  w.suiteId ∈ allowedSuiteIds ∧ w.suiteId ≠ SUITE_ID_SENTINEL
+  w.suiteId ∈ allowedSuiteIds ∧ w.suiteId ≠ RubinFormal.SUITE_ID_SENTINEL
 
 /-- Soft-fork tightening: post-activation validity implies legacy validity.
     This is trivially true because legacy = anyone-can-spend = always valid.
@@ -47,15 +45,15 @@ theorem core_ext_softfork_tightening (allowedSuiteIds : List Nat) (w : WitnessIt
     a witness with suite_id = 0 is accepted pre-activation but rejected post-activation.
     Combined with `core_ext_softfork_tightening`, this shows the rule is a strict subset. -/
 theorem core_ext_active_rejects_sentinel (allowedSuiteIds : List Nat) :
-    ¬ coreExtActiveAllowed allowedSuiteIds { suiteId := SUITE_ID_SENTINEL } := by
-  unfold coreExtActiveAllowed SUITE_ID_SENTINEL
+    ¬ coreExtActiveAllowed allowedSuiteIds { suiteId := RubinFormal.SUITE_ID_SENTINEL } := by
+  unfold coreExtActiveAllowed RubinFormal.SUITE_ID_SENTINEL
   intro ⟨_, hne⟩
   exact hne rfl
 
 /-- The legacy rule accepts SENTINEL — completing the strict tightening proof:
     legacy accepts sentinel, active rejects sentinel. -/
 theorem core_ext_legacy_accepts_sentinel :
-    coreExtLegacyAllowed { suiteId := SUITE_ID_SENTINEL } := by
+    coreExtLegacyAllowed { suiteId := RubinFormal.SUITE_ID_SENTINEL } := by
   trivial
 
 def cursorEnd (inputCount slots : Nat) : Nat :=

--- a/RubinFormal/CovenantGenesisV1.lean
+++ b/RubinFormal/CovenantGenesisV1.lean
@@ -18,7 +18,6 @@ def MAX_MULTISIG_KEYS : Nat := 12
 
 /- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-04):
    creation gate becomes `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def COV_TYPE_P2PK : Nat := 0x0000

--- a/RubinFormal/FormalGap03.lean
+++ b/RubinFormal/FormalGap03.lean
@@ -73,24 +73,24 @@ theorem det001_validation_order_proved : det001ValidationOrderStatement := by
 
 theorem sem001_mldsa_bounded_lengths_proved : sem001MLDSABoundedLengthStatement := by
   intro w blockHeight hSuite
-  have hDistinct : ¬CovenantGenesisV1.SUITE_ID_ML_DSA_87 = CovenantGenesisV1.SUITE_ID_SENTINEL := by
+  have hDistinct : ¬CovenantGenesisV1.SUITE_ID_ML_DSA_87 = 0 := by
     native_decide
   by_cases hPub : w.pubkey.size = UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES
   · by_cases hSig0 : w.signature.size = 0
     · simp [sem001MLDSABoundedLengthStatement, validateWitnessItemLengths, hSuite,
-        UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+        UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, RubinFormal.SUITE_ID_SENTINEL,
         hDistinct, hPub, hSig0]
     · by_cases hSigB : w.signature.size > UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES + 1
       · simp [sem001MLDSABoundedLengthStatement, validateWitnessItemLengths, hSuite,
-          UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+          UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, RubinFormal.SUITE_ID_SENTINEL,
           hDistinct, hPub, hSig0, hSigB]
       · have hSigLe : w.signature.size ≤ UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES + 1 := by omega
         have hSigPos : 0 < w.signature.size := by omega
         simp [sem001MLDSABoundedLengthStatement, validateWitnessItemLengths, hSuite,
-          UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+          UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, RubinFormal.SUITE_ID_SENTINEL,
           hDistinct, hPub, hSig0, hSigB, hSigLe, hSigPos, Pure.pure]; rfl
   · simp [sem001MLDSABoundedLengthStatement, validateWitnessItemLengths, hSuite,
-      UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, UtxoApplyGenesisV1.SUITE_ID_SENTINEL,
+      UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, RubinFormal.SUITE_ID_SENTINEL,
       hDistinct, hPub]
 
 set_option maxHeartbeats 1000000 in

--- a/RubinFormal/LegacySunset.lean
+++ b/RubinFormal/LegacySunset.lean
@@ -29,8 +29,8 @@ open NativeSpendCreateGate
 
 /-- Before H4 (or H4 undefined), old suite is in NATIVE_SPEND_SUITES(h). -/
 theorem fi_rot_06_old_suite_spendable_before_h4
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (_hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (_hwf : wellFormedDescriptor reg d)
     (hno_sunset : d.h4 = none ∨ ∃ h4val, d.h4 = some h4val ∧ h < h4val) :
     d.oldSuiteId ∈ NativeSpendSuites h d := by
   unfold NativeSpendSuites
@@ -46,21 +46,21 @@ theorem fi_rot_06_old_suite_spendable_before_h4
 
 /-- Before H4, old suite spend gate accepts. -/
 theorem fi_rot_06_old_suite_spend_accepted_before_h4
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (hno_sunset : d.h4 = none ∨ ∃ h4val, d.h4 = some h4val ∧ h < h4val) :
     nativeSpendGate d h d.oldSuiteId = GateResult.accept := by
-  have hmem := fi_rot_06_old_suite_spendable_before_h4 d h hwf hno_sunset
+  have hmem := fi_rot_06_old_suite_spendable_before_h4 reg d h hwf hno_sunset
   exact (fi_rot_04_spend_gate_iff d h d.oldSuiteId).mpr hmem
 
 /-- At/after H4, old suite is NOT in NATIVE_SPEND_SUITES(h). -/
 theorem fi_rot_06_old_suite_not_spendable_after_h4
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (h4val : Nat) (hh4 : d.h4 = some h4val) (hge : h4val ≤ h) :
     d.oldSuiteId ∉ NativeSpendSuites h d := by
   unfold NativeSpendSuites
-  obtain ⟨hneq, _, _, hh12, hh24⟩ := hwf
+  obtain ⟨hneq, _, _, _, hh12, hh24⟩ := hwf
   split
   · -- h < h1: spend = [old], but h4val ≤ h and h1 < h2 < h4val, contradiction
     have : d.h2 < h4val := hh24 h4val hh4
@@ -72,21 +72,21 @@ theorem fi_rot_06_old_suite_not_spendable_after_h4
     This is the universal sunset: ALL native covenant types (P2PK, MULTISIG,
     VAULT, STEALTH) reject old suite spends after H4. -/
 theorem fi_rot_06_old_suite_rejected_after_h4
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (h4val : Nat) (hh4 : d.h4 = some h4val) (hge : h4val ≤ h) :
     nativeSpendGate d h d.oldSuiteId = GateResult.reject_sig_alg_invalid := by
   exact fi_rot_04_spend_gate_rejects d h d.oldSuiteId
-    (fi_rot_06_old_suite_not_spendable_after_h4 d h hwf h4val hh4 hge)
+    (fi_rot_06_old_suite_not_spendable_after_h4 reg d h hwf h4val hh4 hge)
 
 /-- After H4, new suite remains spendable (new suite is always in spend set
     once h ≥ h1, and H4 > h2 > h1 by well-formedness). -/
 theorem fi_rot_06_new_suite_always_spendable_after_h4
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (h4val : Nat) (hh4 : d.h4 = some h4val) (hge : h4val ≤ h) :
     d.newSuiteId ∈ NativeSpendSuites h d := by
-  obtain ⟨_, _, _, hh12, hh24⟩ := hwf
+  obtain ⟨_, _, _, _, hh12, hh24⟩ := hwf
   have : d.h2 < h4val := hh24 h4val hh4
   unfold NativeSpendSuites
   have : ¬ h < d.h1 := by omega
@@ -101,12 +101,12 @@ theorem fi_rot_06_new_suite_always_spendable_after_h4
 /-- H2 create cutoff only restricts NATIVE_CREATE_SUITES, not NATIVE_SPEND_SUITES.
     After H2, old suite can still be spent (until H4). -/
 theorem fi_rot_06_spend_unaffected_by_h2_create_cutoff
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (_hge_h2 : d.h2 ≤ h)
     (hno_sunset : d.h4 = none ∨ ∃ h4val, d.h4 = some h4val ∧ h < h4val) :
     d.oldSuiteId ∈ NativeSpendSuites h d := by
-  exact fi_rot_06_old_suite_spendable_before_h4 d h hwf hno_sunset
+  exact fi_rot_06_old_suite_spendable_before_h4 reg d h hwf hno_sunset
 
 end LegacySunset
 

--- a/RubinFormal/NativeRegistryResolution.lean
+++ b/RubinFormal/NativeRegistryResolution.lean
@@ -34,16 +34,6 @@ def registryNoDuplicates (reg : SuiteRegistry) : Prop :=
   ∀ (i j : Nat) (hi : i < reg.length) (hj : j < reg.length),
     (reg.get ⟨i, hi⟩).suiteId = (reg.get ⟨j, hj⟩).suiteId → i = j
 
-/-- A suite_id is registered if `registryLookup` returns `some`. -/
-def isRegistered (reg : SuiteRegistry) (sid : Nat) : Prop :=
-  ∃ entry, registryLookup reg sid = some entry
-
-/-- A rotation descriptor is registry-consistent: both old and new suite
-    are present in the registry. -/
-def descriptorRegistryConsistent
-    (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) : Prop :=
-  isRegistered reg d.oldSuiteId ∧ isRegistered reg d.newSuiteId
-
 /-! ### FI-ROT-03: registry resolution deterministic -/
 
 /-- The result of `registryLookup` is deterministic by construction:
@@ -121,10 +111,10 @@ theorem spend_suites_subset
     d.oldSuiteId or d.newSuiteId, both registered by hypothesis. -/
 theorem descriptor_suites_registered
     (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) (h : Nat)
-    (hcons : descriptorRegistryConsistent d reg)
-    (_hwf : wellFormedDescriptor d) :
+    (hwf : wellFormedDescriptor reg d) :
     (∀ sid ∈ NativeCreateSuites h d, isRegistered reg sid) ∧
     (∀ sid ∈ NativeSpendSuites h d, isRegistered reg sid) := by
+  have hcons := wellFormedDescriptor_registryConsistent reg d hwf
   obtain ⟨hold, hnew⟩ := hcons
   constructor
   · intro sid hmem
@@ -144,22 +134,20 @@ theorem descriptor_suites_registered
 theorem fi_rot_03_active_suite_resolves
     (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) (h : Nat) (sid : Nat)
     (hnd : registryNoDuplicates reg)
-    (hcons : descriptorRegistryConsistent d reg)
-    (hwf : wellFormedDescriptor d)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeSpendSuites h d) :
     ∃ entry, registryLookup reg sid = some entry ∧ ∀ e2, registryLookup reg sid = some e2 → e2 = entry := by
-  have ⟨_, hspend⟩ := descriptor_suites_registered d reg h hcons hwf
+  have ⟨_, hspend⟩ := descriptor_suites_registered d reg h hwf
   exact fi_rot_03_unique_entry reg sid hnd (hspend sid hactive)
 
 /-- Same for create suites. -/
 theorem fi_rot_03_active_create_suite_resolves
     (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) (h : Nat) (sid : Nat)
     (hnd : registryNoDuplicates reg)
-    (hcons : descriptorRegistryConsistent d reg)
-    (hwf : wellFormedDescriptor d)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeCreateSuites h d) :
     ∃ entry, registryLookup reg sid = some entry ∧ ∀ e2, registryLookup reg sid = some e2 → e2 = entry := by
-  have ⟨hcreate, _⟩ := descriptor_suites_registered d reg h hcons hwf
+  have ⟨hcreate, _⟩ := descriptor_suites_registered d reg h hwf
   exact fi_rot_03_unique_entry reg sid hnd (hcreate sid hactive)
 
 /-! ### Pre-rotation specialisation -/

--- a/RubinFormal/NativeSpendCreateGate.lean
+++ b/RubinFormal/NativeSpendCreateGate.lean
@@ -105,19 +105,19 @@ theorem fi_rot_04_spend_gate_determined_by_suite
 
 /-- FI-ROT-04: accepted suite is never sentinel (from wellFormedDescriptor). -/
 theorem fi_rot_04_accepted_not_sentinel
-    (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (haccept : nativeSpendGate d h suiteId = GateResult.accept) :
-    suiteId ≠ SUITE_ID_SENTINEL := by
+    suiteId ≠ RubinFormal.SUITE_ID_SENTINEL := by
   have hmem := fi_rot_04_spend_gate_sound d h suiteId haccept
-  exact active_spend_suite_not_sentinel d h suiteId hwf hmem
+  exact active_spend_suite_not_sentinel reg d h suiteId hwf hmem
 where
   active_spend_suite_not_sentinel
-      (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
-      (hwf : wellFormedDescriptor d)
+      (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
+      (hwf : wellFormedDescriptor reg d)
       (hactive : sid ∈ NativeSpendSuites h d) :
-      sid ≠ SUITE_ID_SENTINEL := by
-    obtain ⟨_, holdNS, hnewNS, _, _⟩ := hwf
+      sid ≠ RubinFormal.SUITE_ID_SENTINEL := by
+    obtain ⟨_, holdNS, hnewNS, _, _, _⟩ := hwf
     rcases spend_suites_subset d h sid hactive with rfl | rfl <;> assumption
 
 /-! ### FI-ROT-05: p2pk_create_cutoff_v1 -/
@@ -144,13 +144,13 @@ theorem fi_rot_05_create_gate_rejects
 
 /-- FI-ROT-05 (cutoff corollary): after H2, old suite P2PK creation is invalid. -/
 theorem fi_rot_05_old_suite_rejected_after_h2
-    (d : RotationDeploymentDescriptor) (h : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (hge : d.h2 ≤ h) :
     nativeP2PKCreateGate d h d.oldSuiteId = GateResult.reject_covenant_type_invalid := by
   apply fi_rot_05_create_gate_rejects
   unfold NativeCreateSuites
-  obtain ⟨hneq, _, _, _, _⟩ := hwf
+  obtain ⟨hneq, _, _, _, _, _⟩ := hwf
   have hge1 : ¬ h < d.h1 := by omega
   have hge2 : ¬ h < d.h2 := by omega
   simp [hge1, hge2, List.mem_singleton]
@@ -158,12 +158,12 @@ theorem fi_rot_05_old_suite_rejected_after_h2
 
 /-- FI-ROT-05: accepted create suite is never sentinel. -/
 theorem fi_rot_05_accepted_not_sentinel
-    (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (haccept : nativeP2PKCreateGate d h suiteId = GateResult.accept) :
-    suiteId ≠ SUITE_ID_SENTINEL := by
+    suiteId ≠ RubinFormal.SUITE_ID_SENTINEL := by
   have hmem := fi_rot_05_create_gate_sound d h suiteId haccept
-  obtain ⟨_, holdNS, hnewNS, _, _⟩ := hwf
+  obtain ⟨_, holdNS, hnewNS, _, _, _⟩ := hwf
   rcases create_suites_subset d h suiteId hmem with rfl | rfl <;> assumption
 
 end NativeSpendCreateGate

--- a/RubinFormal/NativeSuiteRotation.lean
+++ b/RubinFormal/NativeSuiteRotation.lean
@@ -35,20 +35,30 @@ structure RotationDeploymentDescriptor where
   h4         : Option Nat  -- old suite spend-ineligible (sunset); None = never
   deriving Repr, DecidableEq
 
-/-- SUITE_ID_SENTINEL constant (0x00) — sentinel is never a valid active suite. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
+/-- A rotation descriptor is registry-consistent if both suites exist in `reg`. -/
+def descriptorRegistryConsistent
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) : Prop :=
+  isRegistered reg d.oldSuiteId ∧ isRegistered reg d.newSuiteId
 
 /-- A descriptor is well-formed per CANONICAL §4.1.3:
     - old ≠ new
     - neither old nor new is SENTINEL (0x00)
+    - old and new are present in the canonical registry
     - h1 < h2
     - if H4 defined, h2 < h4 -/
-def wellFormedDescriptor (d : RotationDeploymentDescriptor) : Prop :=
+def wellFormedDescriptor (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) : Prop :=
   d.oldSuiteId ≠ d.newSuiteId ∧
-  d.oldSuiteId ≠ SUITE_ID_SENTINEL ∧
-  d.newSuiteId ≠ SUITE_ID_SENTINEL ∧
+  d.oldSuiteId ≠ RubinFormal.SUITE_ID_SENTINEL ∧
+  d.newSuiteId ≠ RubinFormal.SUITE_ID_SENTINEL ∧
+  descriptorRegistryConsistent reg d ∧
   d.h1 < d.h2 ∧
   (∀ h4val, d.h4 = some h4val → d.h2 < h4val)
+
+theorem wellFormedDescriptor_registryConsistent
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor)
+    (hwf : wellFormedDescriptor reg d) :
+    descriptorRegistryConsistent reg d :=
+  hwf.2.2.2.1
 
 /-! ### Phase-dependent suite sets (CANONICAL §4.1.2 five-case table) -/
 
@@ -241,11 +251,12 @@ private theorem spend_post_sunset (d : RotationDeploymentDescriptor) (h : Nat)
     the possibility of an implementation returning different results for the
     same height due to overlapping conditions. -/
 theorem fi_rot_02_phase_partition
+    (reg : SuiteRegistry)
     (d : RotationDeploymentDescriptor)
-    (hwf : wellFormedDescriptor d)
+    (hwf : wellFormedDescriptor reg d)
     (h : Nat) :
     RotationPhase d h := by
-  obtain ⟨_hneq, _holdNotSen, _hnewNotSen, _hh12, hh24⟩ := hwf
+  obtain ⟨_hneq, _holdNotSen, _hnewNotSen, _hcons, _hh12, hh24⟩ := hwf
   by_cases hlt1 : h < d.h1
   · -- Phase 1: h < h1
     exact RotationPhase.phase1 hlt1
@@ -303,8 +314,9 @@ def phaseNumber (d : RotationDeploymentDescriptor) (h : Nat) : Nat :=
 /-- All 10 pairwise phase contradictions, proving the five height intervals
     are mutually exclusive under well-formedness. -/
 theorem fi_rot_02_phases_exclusive
+    (reg : SuiteRegistry)
     (d : RotationDeploymentDescriptor)
-    (hwf : wellFormedDescriptor d) (h : Nat) :
+    (hwf : wellFormedDescriptor reg d) (h : Nat) :
     -- Phase 1 vs Phase 2
     ¬ (h < d.h1 ∧ d.h1 ≤ h) ∧
     -- Phase 1 vs Phase 3/4/5 (h < h1 vs h2 ≤ h, using h1 < h2)
@@ -315,7 +327,7 @@ theorem fi_rot_02_phases_exclusive
     ¬ (d.h4 = none ∧ ∃ v, d.h4 = some v) ∧
     -- Phase 4 vs Phase 5 (h < h4val vs h4val ≤ h)
     (∀ h4val, d.h4 = some h4val → ¬ (h < h4val ∧ h4val ≤ h)) := by
-  obtain ⟨_, _, _, hh12, _⟩ := hwf
+  obtain ⟨_, _, _, _, hh12, _⟩ := hwf
   refine ⟨by omega, by omega, by omega, ?_, ?_⟩
   · rintro ⟨hnone, v, hsome⟩; rw [hnone] at hsome; exact Option.noConfusion hsome
   · intro h4val _ ; omega

--- a/RubinFormal/RotationPrelude.lean
+++ b/RubinFormal/RotationPrelude.lean
@@ -62,6 +62,10 @@ structure RotationDescriptor where
 def registryLookup (reg : SuiteRegistry) (sid : Nat) : Option SuiteEntry :=
   reg.find? (fun e => e.suiteId == sid)
 
+/-- A suite_id is registered if `registryLookup` returns `some`. -/
+def isRegistered (reg : SuiteRegistry) (sid : Nat) : Prop :=
+  ∃ entry, registryLookup reg sid = some entry
+
 /-! ### Single-suite (pre-rotation) era constants -/
 
 /-- The ML-DSA-87 registry entry, used throughout the pre-rotation codebase. -/

--- a/RubinFormal/StructuralRulesBehavioral.lean
+++ b/RubinFormal/StructuralRulesBehavioral.lean
@@ -32,13 +32,13 @@ theorem unknown_suite_0x05_rejected :
 /-- Concrete: sentinel with non-empty pubkey is rejected. -/
 theorem sentinel_nonempty_pubkey_rejected :
     UtxoApplyGenesisV1.validateWitnessItemLengths
-      ⟨UtxoApplyGenesisV1.SUITE_ID_SENTINEL, ⟨#[0x01]⟩, ByteArray.empty⟩ 0 =
+      ⟨RubinFormal.SUITE_ID_SENTINEL, ⟨#[0x01]⟩, ByteArray.empty⟩ 0 =
     .error "TX_ERR_PARSE" := by rfl
 
 /-- Concrete: sentinel with empty pubkey+sig is accepted. -/
 theorem sentinel_empty_accepted :
     UtxoApplyGenesisV1.validateWitnessItemLengths
-      ⟨UtxoApplyGenesisV1.SUITE_ID_SENTINEL, ByteArray.empty, ByteArray.empty⟩ 0 =
+      ⟨RubinFormal.SUITE_ID_SENTINEL, ByteArray.empty, ByteArray.empty⟩ 0 =
     .ok () := by rfl
 
 /-! ## R1: Unknown suite — universal rejection -/
@@ -47,16 +47,16 @@ theorem sentinel_empty_accepted :
     with TX_ERR_SIG_ALG_INVALID. LIVE on `validateWitnessItemLengths`. -/
 theorem unknown_suite_rejected_universal
     (w : WitnessItem) (h : Nat)
-    (hNotS : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hNotS : w.suiteId ≠ RubinFormal.SUITE_ID_SENTINEL)
     (hNotM : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_SIG_ALG_INVALID" := by
   have hS : w.suiteId ≠ 0 := by
-    simp [UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at hNotS; exact hNotS
+    simp [RubinFormal.SUITE_ID_SENTINEL] at hNotS; exact hNotS
   have hM : w.suiteId ≠ 1 := by
     simp [UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at hNotM; exact hNotM
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87]
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87]
   simp [hS, hM]; rfl
 
 /-! ## R2: Sentinel — non-empty pubkey or sig rejected -/
@@ -65,11 +65,11 @@ theorem unknown_suite_rejected_universal
     with TX_ERR_PARSE. LIVE on `validateWitnessItemLengths`. -/
 theorem sentinel_nonempty_rejected_universal
     (w : WitnessItem) (h : Nat)
-    (hS : w.suiteId = UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hS : w.suiteId = RubinFormal.SUITE_ID_SENTINEL)
     (hNE : w.pubkey.size ≠ 0 ∨ w.signature.size ≠ 0) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_PARSE" := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at *
+    RubinFormal.SUITE_ID_SENTINEL] at *
   simp only [hS, beq_self_eq_true, ite_true]
   rcases hNE with hp | hs
   · simp [bne_iff_ne, hp, Bool.true_or]; rfl
@@ -81,12 +81,12 @@ theorem sentinel_nonempty_rejected_universal
     LIVE on `validateWitnessItemLengths`. -/
 theorem sentinel_empty_accepted_universal
     (w : WitnessItem) (h : Nat)
-    (hS : w.suiteId = UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hS : w.suiteId = RubinFormal.SUITE_ID_SENTINEL)
     (hPE : w.pubkey.size = 0)
     (hSE : w.signature.size = 0) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_SENTINEL] at *
+    RubinFormal.SUITE_ID_SENTINEL] at *
   simp only [hS, beq_self_eq_true, ite_true]
   simp [bne_iff_ne, hPE, hSE]; rfl
 
@@ -100,9 +100,9 @@ theorem mldsa87_wrong_pubkey_rejected_universal
     (hBad : w.pubkey.size ≠ UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_SIG_NONCANONICAL" := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hBad, Bool.true_or]; rfl
 
 /-! ## R5: ML-DSA-87 — sig bounds rejected -/
@@ -116,9 +116,9 @@ theorem mldsa87_empty_sig_rejected_universal
     (hSig0 : w.signature.size = 0) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_SIG_NONCANONICAL" := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hPOk, hSig0]; rfl
 
 /-- **R5b (universal):** ML-DSA-87 with sig too large is rejected.
@@ -130,9 +130,9 @@ theorem mldsa87_sig_too_large_rejected_universal
     (hBig : w.signature.size > UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES + 1) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .error "TX_ERR_SIG_NONCANONICAL" := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM]
   split
   · rfl
@@ -151,9 +151,9 @@ theorem mldsa87_valid_accepted_universal
     (hSBound : w.signature.size ≤ UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES + 1) :
     UtxoApplyGenesisV1.validateWitnessItemLengths w h = .ok () := by
   simp only [UtxoApplyGenesisV1.validateWitnessItemLengths,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
     UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES, UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
   simp [show w.suiteId ≠ 0 from by omega, hM, bne_iff_ne, hPOk,
         show w.signature.size ≠ 0 from by omega]
   simp [show ¬(4628 < w.signature.size) from by omega]; rfl
@@ -181,13 +181,13 @@ theorem threshold_unknown_suite_head_rejected
     (k : Bytes) (krest : List Bytes) (w : WitnessItem) (wrest : List WitnessItem)
     (h : Nat) (ctx : String) (threshold : Nat)
     (hLen : (w :: wrest).length = (k :: krest).length)
-    (hNotS : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_SENTINEL)
+    (hNotS : w.suiteId ≠ RubinFormal.SUITE_ID_SENTINEL)
     (hNotM : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87) :
     UtxoApplyGenesisV1.validateThresholdSigSpendNoCrypto (k :: krest) threshold (w :: wrest) h ctx =
     .error "TX_ERR_SIG_ALG_INVALID" := by
   simp only [UtxoApplyGenesisV1.validateThresholdSigSpendNoCrypto,
-    UtxoApplyGenesisV1.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
-    CovenantGenesisV1.SUITE_ID_SENTINEL, CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
+    RubinFormal.SUITE_ID_SENTINEL, UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87,
+    CovenantGenesisV1.SUITE_ID_ML_DSA_87] at *
   have hLen' : wrest.length = krest.length := by simp [List.length] at hLen; omega
   simp [hLen', hNotS, hNotM]
   show Except.error "TX_ERR_SIG_ALG_INVALID" = Except.error "TX_ERR_SIG_ALG_INVALID"; rfl

--- a/RubinFormal/TxParseV2.lean
+++ b/RubinFormal/TxParseV2.lean
@@ -20,7 +20,6 @@ def MAX_COVENANT_DATA_PER_OUTPUT : Nat := 65536
 
 /- Pre-rotation suite constants.  Post-rotation (Q-FORMAL-ROTATION-02/03):
    replace with registry lookup via `Rotation.SuiteRegistry`. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
@@ -80,7 +79,7 @@ def parseWitnessItem (c : Cursor) : Option (Cursor × Option TxErr) := do
   let (sig, c5) ← c4.getBytes? sigLen
 
   -- Canonicalization rules (CANONICAL §5.4).
-  if suiteID == SUITE_ID_SENTINEL then
+  if suiteID == RubinFormal.SUITE_ID_SENTINEL then
     if pubLen == 0 && sigLen == 0 then
       pure (c5, none)
     else if pubLen == 32 then

--- a/RubinFormal/TxWeightV2.lean
+++ b/RubinFormal/TxWeightV2.lean
@@ -22,7 +22,6 @@ def MAX_WITNESS_BYTES_PER_TX : Nat := 100000
 
 /- Pre-rotation suite ID constants.  See `RotationPrelude.lean` for
    the registry-based model used by Q-FORMAL-ROTATION-01..06. -/
-def SUITE_ID_SENTINEL : Nat := 0x00
 def SUITE_ID_ML_DSA_87 : Nat := 0x01
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
@@ -91,7 +90,7 @@ def parseWitnessItemForCounts (c : Cursor) : Option (Cursor × Bool × Bool × B
   let _ ← requireMinimal minimal2
   let (sig, c5) ← c4.getBytes? sigLen
 
-  if suiteID == SUITE_ID_SENTINEL then
+  if suiteID == RubinFormal.SUITE_ID_SENTINEL then
     -- canonical sentinel encodings (see CANONICAL §5.4); only needed to preserve parse parity
     if pubLen == 0 && sigLen == 0 then
       pure (c5, false, false, false)

--- a/RubinFormal/Types.lean
+++ b/RubinFormal/Types.lean
@@ -33,4 +33,10 @@ instance : Repr Bytes where
 instance : Inhabited Bytes where
   default := ByteArray.empty
 
+/-- Canonical suite ID constants (CANONICAL §2.3 / §5.4).
+    Rotation/covenant/validator modules must reuse these definitions instead
+    of carrying local copies, so theorem users share one sentinel source. -/
+def SUITE_ID_SENTINEL : Nat := 0x00
+def SUITE_ID_ML_DSA_87 : Nat := 0x01
+
 end RubinFormal

--- a/RubinFormal/UtxoApplyGenesisV1.lean
+++ b/RubinFormal/UtxoApplyGenesisV1.lean
@@ -14,7 +14,6 @@ open RubinFormal.CovenantGenesisV1
 
 /- Pre-rotation suite constants (re-exported from CovenantGenesisV1).
    Post-rotation (Q-FORMAL-ROTATION-02/04): use `Rotation.registryLookup`. -/
-def SUITE_ID_SENTINEL : Nat := CovenantGenesisV1.SUITE_ID_SENTINEL
 def SUITE_ID_ML_DSA_87 : Nat := CovenantGenesisV1.SUITE_ID_ML_DSA_87
 
 def ML_DSA_87_PUBKEY_BYTES : Nat := 2592
@@ -57,7 +56,7 @@ def validateP2PKSpendPreSig (entry : UtxoEntry) (w : WitnessItem) (_blockHeight 
 /-- **Pre-rotation scope**: hardcoded ML-DSA-87 pubkey/sig bounds.
     Post-rotation (Q-FORMAL-ROTATION-02): bounds from `Rotation.registryLookup`. -/
 def validateWitnessItemLengths (w : WitnessItem) (_blockHeight : Nat) : Except String Unit := do
-  if w.suiteId == SUITE_ID_SENTINEL then
+  if w.suiteId == RubinFormal.SUITE_ID_SENTINEL then
     if w.pubkey.size != 0 || w.signature.size != 0 then
       throw "TX_ERR_PARSE"
     pure ()
@@ -80,7 +79,7 @@ def validateThresholdSigSpendNoCrypto
     throw "TX_ERR_PARSE"
   let mut valid : Nat := 0
   for (w, key) in List.zip ws keys do
-    if w.suiteId == SUITE_ID_SENTINEL then
+    if w.suiteId == RubinFormal.SUITE_ID_SENTINEL then
       pure ()
     else if w.suiteId == SUITE_ID_ML_DSA_87 then
       if SHA3.sha3_256 w.pubkey != key then
@@ -100,7 +99,7 @@ def validateHTLCSpendNoCrypto
     (blockMtp : Nat) : Except String Unit := do
   let c ← CovenantGenesisV1.parseHtlcCovenantData entry.covenantData
 
-  if pathItem.suiteId != SUITE_ID_SENTINEL then
+  if pathItem.suiteId != RubinFormal.SUITE_ID_SENTINEL then
     throw "TX_ERR_PARSE"
   if pathItem.pubkey.size != 32 then
     throw "TX_ERR_PARSE"

--- a/RubinFormal/WeightSuiteAware.lean
+++ b/RubinFormal/WeightSuiteAware.lean
@@ -42,7 +42,7 @@ open TxWeightV2
     Looks up verifyCost from registry; falls back to VERIFY_COST_UNKNOWN_SUITE
     for unregistered suites; sentinel has zero cost. -/
 def suiteAwareCost (reg : SuiteRegistry) (suiteId : Nat) : Nat :=
-  if suiteId == TxWeightV2.SUITE_ID_SENTINEL then 0
+  if suiteId == RubinFormal.SUITE_ID_SENTINEL then 0
   else match registryLookup reg suiteId with
   | some entry => entry.verifyCost
   | none       => TxWeightV2.VERIFY_COST_UNKNOWN_SUITE
@@ -59,11 +59,11 @@ private theorem nat_beq_ne_zero {n : Nat} (h : n ≠ 0) : Nat.beq n 0 = false :=
 
 /-- Helper: suiteAwareCost unfolds for non-sentinel suites. -/
 private theorem suiteAwareCost_nonSentinel (reg : SuiteRegistry) (sid : Nat)
-    (h : sid ≠ TxWeightV2.SUITE_ID_SENTINEL) :
+    (h : sid ≠ RubinFormal.SUITE_ID_SENTINEL) :
     suiteAwareCost reg sid = match registryLookup reg sid with
       | some entry => entry.verifyCost
       | none => TxWeightV2.VERIFY_COST_UNKNOWN_SUITE := by
-  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL
+  unfold suiteAwareCost RubinFormal.SUITE_ID_SENTINEL
   have hbeq : (sid == (0 : Nat)) = false := by
     show Nat.beq sid 0 = false
     exact nat_beq_ne_zero h
@@ -94,8 +94,8 @@ theorem fi_rot_03_total_sig_cost_deterministic
 
 /-- Sentinel suite has zero cost. -/
 theorem fi_rot_03_sentinel_zero_cost (reg : SuiteRegistry) :
-    suiteAwareCost reg TxWeightV2.SUITE_ID_SENTINEL = 0 := by
-  unfold suiteAwareCost TxWeightV2.SUITE_ID_SENTINEL
+    suiteAwareCost reg RubinFormal.SUITE_ID_SENTINEL = 0 := by
+  unfold suiteAwareCost RubinFormal.SUITE_ID_SENTINEL
   simp
 
 /-- ML-DSA-87 cost matches hardcoded VERIFY_COST_ML_DSA_87 in pre-rotation registry. -/
@@ -106,7 +106,7 @@ theorem fi_rot_03_ml_dsa_cost_matches :
 
 /-- Unknown suite cost matches VERIFY_COST_UNKNOWN_SUITE in pre-rotation registry. -/
 theorem fi_rot_03_unknown_suite_cost (sid : Nat)
-    (hnotSentinel : sid ≠ TxWeightV2.SUITE_ID_SENTINEL)
+    (hnotSentinel : sid ≠ RubinFormal.SUITE_ID_SENTINEL)
     (hnotRegistered : registryLookup PRE_ROTATION_REGISTRY sid = none) :
     suiteAwareCost PRE_ROTATION_REGISTRY sid =
     TxWeightV2.VERIFY_COST_UNKNOWN_SUITE := by
@@ -119,21 +119,21 @@ theorem fi_rot_03_unknown_suite_cost (sid : Nat)
 
 /-- Any spend-active suite is not sentinel. -/
 theorem active_spend_suite_not_sentinel
-    (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeSpendSuites h d) :
-    sid ≠ NativeSuiteRotation.SUITE_ID_SENTINEL := by
-  obtain ⟨_, holdNS, hnewNS, _, _⟩ := hwf
+    sid ≠ RubinFormal.SUITE_ID_SENTINEL := by
+  obtain ⟨_, holdNS, hnewNS, _, _, _⟩ := hwf
   have hor := NativeRegistryResolution.spend_suites_subset d h sid hactive
   rcases hor with rfl | rfl <;> assumption
 
 /-- Any create-active suite is not sentinel. -/
 theorem active_create_suite_not_sentinel
-    (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
-    (hwf : wellFormedDescriptor d)
+    (reg : SuiteRegistry) (d : RotationDeploymentDescriptor) (h : Nat) (sid : Nat)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeCreateSuites h d) :
-    sid ≠ NativeSuiteRotation.SUITE_ID_SENTINEL := by
-  obtain ⟨_, holdNS, hnewNS, _, _⟩ := hwf
+    sid ≠ RubinFormal.SUITE_ID_SENTINEL := by
+  obtain ⟨_, holdNS, hnewNS, _, _, _⟩ := hwf
   have hor := NativeRegistryResolution.create_suites_subset d h sid hactive
   rcases hor with rfl | rfl <;> assumption
 
@@ -157,14 +157,13 @@ theorem active_create_suite_not_sentinel
 theorem weight_suite_aware_correct
     (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) (h : Nat) (sid : Nat)
     (hnd : registryNoDuplicates reg)
-    (hcons : descriptorRegistryConsistent d reg)
-    (hwf : wellFormedDescriptor d)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeSpendSuites h d) :
     ∃ entry, registryLookup reg sid = some entry ∧
       suiteAwareCost reg sid = entry.verifyCost := by
-  have hnotSentinel : sid ≠ TxWeightV2.SUITE_ID_SENTINEL :=
-    active_spend_suite_not_sentinel d h sid hwf hactive
-  have ⟨entry, hlookup, _⟩ := fi_rot_03_active_suite_resolves d reg h sid hnd hcons hwf hactive
+  have hnotSentinel : sid ≠ RubinFormal.SUITE_ID_SENTINEL :=
+    active_spend_suite_not_sentinel reg d h sid hwf hactive
+  have ⟨entry, hlookup, _⟩ := fi_rot_03_active_suite_resolves d reg h sid hnd hwf hactive
   refine ⟨entry, hlookup, ?_⟩
   rw [suiteAwareCost_nonSentinel _ _ hnotSentinel, hlookup]
 
@@ -172,14 +171,13 @@ theorem weight_suite_aware_correct
 theorem weight_suite_aware_correct_create
     (d : RotationDeploymentDescriptor) (reg : SuiteRegistry) (h : Nat) (sid : Nat)
     (hnd : registryNoDuplicates reg)
-    (hcons : descriptorRegistryConsistent d reg)
-    (hwf : wellFormedDescriptor d)
+    (hwf : wellFormedDescriptor reg d)
     (hactive : sid ∈ NativeCreateSuites h d) :
     ∃ entry, registryLookup reg sid = some entry ∧
       suiteAwareCost reg sid = entry.verifyCost := by
-  have hnotSentinel : sid ≠ TxWeightV2.SUITE_ID_SENTINEL :=
-    active_create_suite_not_sentinel d h sid hwf hactive
-  have ⟨entry, hlookup, _⟩ := fi_rot_03_active_create_suite_resolves d reg h sid hnd hcons hwf hactive
+  have hnotSentinel : sid ≠ RubinFormal.SUITE_ID_SENTINEL :=
+    active_create_suite_not_sentinel reg d h sid hwf hactive
+  have ⟨entry, hlookup, _⟩ := fi_rot_03_active_create_suite_resolves d reg h sid hnd hwf hactive
   refine ⟨entry, hlookup, ?_⟩
   rw [suiteAwareCost_nonSentinel _ _ hnotSentinel, hlookup]
 
@@ -192,7 +190,7 @@ theorem fi_rot_03_pre_rotation_two_sigs :
 /-- Pre-rotation concrete check: totalSigCost for [SENTINEL, ML_DSA_87] = 8. -/
 theorem fi_rot_03_pre_rotation_sentinel_plus_sig :
     totalSigCost PRE_ROTATION_REGISTRY
-      [TxWeightV2.SUITE_ID_SENTINEL, TxWeightV2.SUITE_ID_ML_DSA_87] = 8 := by
+      [RubinFormal.SUITE_ID_SENTINEL, TxWeightV2.SUITE_ID_ML_DSA_87] = 8 := by
   native_decide
 
 end WeightSuiteAware


### PR DESCRIPTION
## Summary
- strengthen `wellFormedDescriptor` so rotation descriptors require registry consistency
- collapse `SUITE_ID_SENTINEL` to the canonical `RubinFormal.Types` source
- rewire dependent rotation and behavioral theorems to the new live contracts

## Validation
- `lake build`

Closes #283
Closes #284
