### PR TITLE
fix: parametrize pre-rotation registry, harden RBMap lifting

### DIFF
--- a/RubinFormal/NativeRegistryResolution.lean
+++ b/RubinFormal/NativeRegistryResolution.lean
@@ -150,19 +150,33 @@ theorem fi_rot_03_active_create_suite_resolves
   have ⟨hcreate, _⟩ := descriptor_suites_registered d reg h hwf
   exact fi_rot_03_unique_entry reg sid hnd (hcreate sid hactive)
 
-/-! ### Pre-rotation specialisation -/
+/-! ### Canonical single-suite registry theorems (#287)
 
-/-- In the pre-rotation registry, ML-DSA-87 resolves correctly. -/
+  Parametric versions that take any registry equal to `[ML_DSA_87_ENTRY]`,
+  removing hard dependence on the `PRE_ROTATION_REGISTRY` constant.
+  The pre-rotation specialisations are backward-compatible corollaries. -/
+
+/-- Any single-ML-DSA-87 registry resolves suite 0x01 to ML_DSA_87_ENTRY. -/
+theorem single_ml_dsa_registry_resolves (reg : SuiteRegistry)
+    (hreg : reg = [ML_DSA_87_ENTRY]) :
+    registryLookup reg 0x01 = some ML_DSA_87_ENTRY := by
+  subst hreg; native_decide
+
+/-- Any single-entry registry trivially has no duplicate suite IDs. -/
+theorem single_entry_registry_no_duplicates (reg : SuiteRegistry) (e : SuiteEntry)
+    (hreg : reg = [e]) :
+    registryNoDuplicates reg := by
+  subst hreg; intro i j hi hj _; simp at hi hj; omega
+
+/-- Pre-rotation corollary: ML-DSA-87 resolves correctly. -/
 theorem fi_rot_03_pre_rotation_ml_dsa_resolves :
-    registryLookup PRE_ROTATION_REGISTRY 0x01 = some ML_DSA_87_ENTRY := by
-  native_decide
+    registryLookup PRE_ROTATION_REGISTRY 0x01 = some ML_DSA_87_ENTRY :=
+  single_ml_dsa_registry_resolves PRE_ROTATION_REGISTRY rfl
 
-/-- The pre-rotation registry has no duplicate suite IDs. -/
+/-- Pre-rotation corollary: no duplicate suite IDs. -/
 theorem fi_rot_03_pre_rotation_no_duplicates :
-    registryNoDuplicates PRE_ROTATION_REGISTRY := by
-  intro i j hi hj _
-  simp [PRE_ROTATION_REGISTRY] at hi hj
-  omega
+    registryNoDuplicates PRE_ROTATION_REGISTRY :=
+  single_entry_registry_no_duplicates PRE_ROTATION_REGISTRY ML_DSA_87_ENTRY rfl
 
 end NativeRegistryResolution
 

--- a/RubinFormal/UtxoMapProperties.lean
+++ b/RubinFormal/UtxoMapProperties.lean
@@ -201,41 +201,35 @@ theorem rbmap_contains_insert_self (k : Outpoint) (v : UtxoEntry)
     (t.insert k v).contains k = true := by
   simp [Std.RBMap.contains, rbmap_findEntry_insert_self k v t]
 
-/-! ## Insert-of-ne lifting: inserting with key k' preserves find? for key k ≠ k'. -/
+/-! ## Insert-of-ne lifting: inserting with key k' preserves find? for key k ≠ k'.
+
+  (#288) RBMap.findEntry? uses cut `(· |>.1 |> cmpOutpoint k)` while
+  RBSet.find? uses full pair comparison `utxoPairCmp (k, v)`.  These are
+  definitionally equal because `utxoPairCmp` is `Ordering.byKey Prod.fst cmpOutpoint`.
+  The helper `findP_eq_pair_find` factors out this equivalence so the main
+  proof never uses the fragile `change` tactic. -/
+
+/-- The RBMap key-projection cut equals the RBSet pair comparison for any dummy value.
+    This is the key lifting lemma: `findP? (cmpOutpoint k ·.1)` ≡ `find? utxoPairCmp (k, dummy)`. -/
+private theorem findP_eq_pair_find (k : Outpoint) (dummy : UtxoEntry)
+    (t : Std.RBSet (Outpoint × UtxoEntry) utxoPairCmp) :
+    t.findP? (fun x => cmpOutpoint k x.1) = t.find? (k, dummy) := by
+  simp only [Std.RBSet.findP?, Std.RBSet.find?]
+  congr 1
 
 /-- Inserting a different key preserves findEntry? for the original key.
-    Uses RBSet.find?_insert_of_ne with a dummy entry to match the RBSet API. -/
+    Uses `findP_eq_pair_find` to bridge RBMap (key-cut) ↔ RBSet (pair-find),
+    then delegates to `Std.RBSet.find?_insert_of_ne`. -/
 theorem rbmap_findEntry_insert_of_ne (k k' : Outpoint) (v : UtxoEntry)
     (t : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (hne : cmpOutpoint k k' ≠ .eq) :
     (t.insert k' v).findEntry? k = t.findEntry? k := by
-  -- Use RBSet.find?_insert_of_ne at the RBSet level
-  -- RBMap is an RBSet of pairs; findEntry? k = RBSet.findP? (cmpOutpoint k ·.1)
-  -- But RBSet.find? uses full pair comparison, while findP? uses a cut.
-  -- Approach: use the RBSet.find?_insert_of_ne lemma indirectly via findP?
-  -- Actually simpler: RBMap.findEntry? unfolds to RBSet.findP? which is RBNode.find?
-  simp only [Std.RBMap.insert, Std.RBMap.findEntry?, Std.RBSet.findP?, Std.RBSet.insert]
-  -- Goal: RBNode.find? (fun x => cmpOutpoint k x.1) (RBNode.insert pairCmp t.val (k',v))
-  --     = RBNode.find? (fun x => cmpOutpoint k x.1) t.val
-  -- The cut is (fun x => cmpOutpoint k x.1) and the inserted value is (k', v)
-  -- cut (k', v) = cmpOutpoint k k' ≠ .eq (by hne)
-  -- Use the RBNode-level find?_insert from Std4 RBSet.find?_insert_of_ne proof
-  -- RBSet.find?_insert_of_ne: cmp v' v ≠ .eq → (t.insert v).find? v' = t.find? v'
-  -- At RBSet level: t = our RBMap as RBSet, v = (k', v_entry), v' = (k, dummy)
-  -- cmp (k, dummy) (k', v_entry) = cmpOutpoint k k' ≠ .eq ✓
-  -- (t.insert (k',v)).find? (k, dummy) = t.find? (k, dummy)
-  -- And find? (k, dummy) = RBNode.find? (pairCmp (k, dummy)) = RBNode.find? (fun x => cmpOutpoint k x.1)
-  -- Which is exactly findEntry? k
-  -- So: use RBSet.find?_insert_of_ne directly
-  change (Std.RBSet.insert (α := Outpoint × UtxoEntry) t (k', v)).1.find?
-    (utxoPairCmp (k, v)) =
-    t.1.find? (utxoPairCmp (k, v))
-  have := Std.RBSet.find?_insert_of_ne (cmp := utxoPairCmp) t
+  simp only [Std.RBMap.findEntry?, Std.RBMap.insert]
+  rw [findP_eq_pair_find k v (Std.RBSet.insert t (k', v)),
+      findP_eq_pair_find k v t]
+  exact Std.RBSet.find?_insert_of_ne (cmp := utxoPairCmp) t
     (v := (k', v)) (v' := (k, v))
     (by simp [utxoPairCmp, Ordering.byKey]; exact hne)
-  -- `this` should be about RBSet.find?, which wraps RBNode.find?
-  simp only [Std.RBSet.find?, Std.RBSet.insert] at this
-  exact this
 
 /-- Inserting a different key preserves find? for the original key. -/
 theorem rbmap_find_insert_of_ne (k k' : Outpoint) (v' : UtxoEntry)

--- a/RubinFormal/WeightSuiteAware.lean
+++ b/RubinFormal/WeightSuiteAware.lean
@@ -98,19 +98,34 @@ theorem fi_rot_03_sentinel_zero_cost (reg : SuiteRegistry) :
   unfold suiteAwareCost RubinFormal.SUITE_ID_SENTINEL
   simp
 
-/-- ML-DSA-87 cost matches hardcoded VERIFY_COST_ML_DSA_87 in pre-rotation registry. -/
+/-- ML-DSA-87 cost matches VERIFY_COST_ML_DSA_87 in any single-ML-DSA-87 registry (#287). -/
+theorem ml_dsa_cost_matches_canonical (reg : SuiteRegistry)
+    (hreg : reg = [ML_DSA_87_ENTRY]) :
+    suiteAwareCost reg TxWeightV2.SUITE_ID_ML_DSA_87 =
+    TxWeightV2.VERIFY_COST_ML_DSA_87 := by
+  subst hreg; native_decide
+
+/-- Pre-rotation corollary. -/
 theorem fi_rot_03_ml_dsa_cost_matches :
     suiteAwareCost PRE_ROTATION_REGISTRY TxWeightV2.SUITE_ID_ML_DSA_87 =
-    TxWeightV2.VERIFY_COST_ML_DSA_87 := by
-  native_decide
+    TxWeightV2.VERIFY_COST_ML_DSA_87 :=
+  ml_dsa_cost_matches_canonical PRE_ROTATION_REGISTRY rfl
 
-/-- Unknown suite cost matches VERIFY_COST_UNKNOWN_SUITE in pre-rotation registry. -/
+/-- Unknown suite cost matches VERIFY_COST_UNKNOWN_SUITE in any registry (#287). -/
+theorem unknown_suite_cost_any_registry (reg : SuiteRegistry) (sid : Nat)
+    (hnotSentinel : sid ≠ RubinFormal.SUITE_ID_SENTINEL)
+    (hnotRegistered : registryLookup reg sid = none) :
+    suiteAwareCost reg sid =
+    TxWeightV2.VERIFY_COST_UNKNOWN_SUITE := by
+  rw [suiteAwareCost_nonSentinel _ _ hnotSentinel, hnotRegistered]
+
+/-- Pre-rotation corollary. -/
 theorem fi_rot_03_unknown_suite_cost (sid : Nat)
     (hnotSentinel : sid ≠ RubinFormal.SUITE_ID_SENTINEL)
     (hnotRegistered : registryLookup PRE_ROTATION_REGISTRY sid = none) :
     suiteAwareCost PRE_ROTATION_REGISTRY sid =
-    TxWeightV2.VERIFY_COST_UNKNOWN_SUITE := by
-  rw [suiteAwareCost_nonSentinel _ _ hnotSentinel, hnotRegistered]
+    TxWeightV2.VERIFY_COST_UNKNOWN_SUITE :=
+  unknown_suite_cost_any_registry PRE_ROTATION_REGISTRY sid hnotSentinel hnotRegistered
 
 /-! ### Active suites are never sentinel
 
@@ -181,17 +196,31 @@ theorem weight_suite_aware_correct_create
   refine ⟨entry, hlookup, ?_⟩
   rw [suiteAwareCost_nonSentinel _ _ hnotSentinel, hlookup]
 
-/-- Pre-rotation concrete check: totalSigCost for [ML_DSA_87, ML_DSA_87] = 16. -/
+/-- Two ML-DSA-87 sigs cost 16 in any single-ML-DSA-87 registry (#287). -/
+theorem two_ml_dsa_sigs_cost_canonical (reg : SuiteRegistry)
+    (hreg : reg = [ML_DSA_87_ENTRY]) :
+    totalSigCost reg
+      [TxWeightV2.SUITE_ID_ML_DSA_87, TxWeightV2.SUITE_ID_ML_DSA_87] = 16 := by
+  subst hreg; native_decide
+
+/-- Pre-rotation corollary. -/
 theorem fi_rot_03_pre_rotation_two_sigs :
     totalSigCost PRE_ROTATION_REGISTRY
-      [TxWeightV2.SUITE_ID_ML_DSA_87, TxWeightV2.SUITE_ID_ML_DSA_87] = 16 := by
-  native_decide
+      [TxWeightV2.SUITE_ID_ML_DSA_87, TxWeightV2.SUITE_ID_ML_DSA_87] = 16 :=
+  two_ml_dsa_sigs_cost_canonical PRE_ROTATION_REGISTRY rfl
 
-/-- Pre-rotation concrete check: totalSigCost for [SENTINEL, ML_DSA_87] = 8. -/
+/-- Sentinel + ML-DSA-87 costs 8 in any single-ML-DSA-87 registry (#287). -/
+theorem sentinel_plus_ml_dsa_cost_canonical (reg : SuiteRegistry)
+    (hreg : reg = [ML_DSA_87_ENTRY]) :
+    totalSigCost reg
+      [RubinFormal.SUITE_ID_SENTINEL, TxWeightV2.SUITE_ID_ML_DSA_87] = 8 := by
+  subst hreg; native_decide
+
+/-- Pre-rotation corollary. -/
 theorem fi_rot_03_pre_rotation_sentinel_plus_sig :
     totalSigCost PRE_ROTATION_REGISTRY
-      [RubinFormal.SUITE_ID_SENTINEL, TxWeightV2.SUITE_ID_ML_DSA_87] = 8 := by
-  native_decide
+      [RubinFormal.SUITE_ID_SENTINEL, TxWeightV2.SUITE_ID_ML_DSA_87] = 8 :=
+  sentinel_plus_ml_dsa_cost_canonical PRE_ROTATION_REGISTRY rfl
 
 end WeightSuiteAware
 


### PR DESCRIPTION
## Summary

- #287 (F-106): Pre-rotation theorems now delegate to parametric versions that accept any reg = [ML_DSA_87_ENTRY]. Original names preserved as backward-compatible corollaries.
- #288 (F-209): rbmap_findEntry_insert_of_ne no longer uses fragile change tactic. New findP_eq_pair_find helper bridges RBMap key-cut to RBSet pair-find.

## Verification

- lake env lean passes for all three files
- All original theorem names preserved

Closes #287, closes #288.
