### PR TITLE
fix: define dedup key in security-review workflow

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -347,6 +347,7 @@ jobs:
                 const allMissing = refs.every((name) => !content.includes(name));
                 if (allMissing) continue;
               }
+              const key = `${f.file}:${f.line}:${cat}`;
               if (seen.has(key)) continue;
               seen.add(key);
               filtered.push(f);


### PR DESCRIPTION
## Summary
- The `key` variable was used in `seen.has(key)` / `seen.add(key)` for finding deduplication but never defined
- Every security-review run crashed with `ReferenceError: key is not defined`
- Fix: `const key = \`${f.file}:${f.line}:${cat}\`` before the dedup check

## Test plan
- [ ] security-review CI job completes without ReferenceError
- [ ] Duplicate findings are correctly filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)