### PR TITLE
formal: restore txid non-cv theorem surface

### DIFF
--- a/RubinFormal/TxIdBehavioral.lean
+++ b/RubinFormal/TxIdBehavioral.lean
@@ -1,5 +1,6 @@
 import RubinFormal.CriticalInvariants
 import RubinFormal.MerkleV2
+import RubinFormal.MerkleStructure
 
 /-!
 # TXID/WTXID Behavioral Proofs (§8)
@@ -30,5 +31,24 @@ theorem all_merkle_tags_distinct :
     (0x02 : UInt8) ≠ 0x03 := by native_decide
 
 -- txid_wtxid_preimage_bytes_distinct already proved in CriticalInvariants.lean
+
+/-- For transactions with a non-empty witness section, the actual txid preimage
+    bytes (`tx.extract 0 coreEnd`) differ from the full-transaction wtxid
+    preimage bytes (`tx`). This is the non-fixture structural core of §8. -/
+theorem txid_wtxid_payloads_distinct_when_witness_present
+    (tx : ByteArray) (coreEnd : Nat) (h : coreEnd < tx.size) :
+    tx.extract 0 coreEnd ≠ tx := by
+  exact txid_wtxid_preimage_bytes_distinct tx coreEnd h
+
+/-- Section-level contract for identifier-domain separation:
+    when witness is present, the raw txid and wtxid payloads already diverge,
+    and the tagged leaf-preimage domains used by the Merkle layer are disjoint. -/
+theorem txid_wtxid_identifier_domain_contract
+    (tx : ByteArray) (coreEnd : Nat) (h : coreEnd < tx.size) :
+    tx.extract 0 coreEnd ≠ tx ∧
+    Merkle.txidLeafPreimage (tx.extract 0 coreEnd) ≠ Merkle.wtxidLeafPreimage tx := by
+  constructor
+  · exact txid_wtxid_payloads_distinct_when_witness_present tx coreEnd h
+  · exact Merkle.merkle_tag_equivalence_leaf_domains_disjoint (tx.extract 0 coreEnd) tx
 
 end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -102,14 +102,22 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_parse_vectors_pass",
-        "RubinFormal.Conformance.cv_sig_vectors_pass"
+        "RubinFormal.Conformance.cv_sig_vectors_pass",
+        "RubinFormal.transaction_identifiers_proved",
+        "RubinFormal.txid_wtxid_identifier_domain_contract"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "cv_replay_only",
+      "theorem_files": {
+        "RubinFormal.transaction_identifiers_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
+        "RubinFormal.txid_wtxid_identifier_domain_contract": "rubin-formal/RubinFormal/TxIdBehavioral.lean"
+      },
+      "evidence_level": "machine_checked_contract",
       "limitations": [
-        "This section is evidenced by conformance vector replay only (native_decide). No structural or behavioral theorems are present. Coverage is bounded by the fixture set."
+        "This remains a contract-level section: the non-fixture theorem surface proves preimage/domain separation for the witness-present path, while CV-PARSE/CV-SIG replay covers concrete emitted txid/wtxid outputs on the shipped fixtures.",
+        "No universal claim is made that SHA3(tx.extract 0 coreEnd) and SHA3(tx) differ as digests for every raw transaction; that would require an explicit cryptographic collision-resistance assumption beyond the current structural proofs.",
+        "Witness-empty transactions still rely on the executable replay path for concrete txid=wtxid behavior; this row does not claim a full end-to-end theorem over every parse path in TxParseV2."
       ],
-      "notes": "CV replay pass only. No additional structural or behavioral theorems for this section."
+      "notes": "Section §8 is no longer replay-only: `transaction_identifiers_proved` restores the real-byte preimage distinctness theorem from `PinnedSections/CriticalInvariants`, and `txid_wtxid_identifier_domain_contract` adds a section-local contract theorem tying those payload bytes to the actual txid/wtxid Merkle leaf domains. CV-PARSE and CV-SIG replay remain the executable evidence for concrete emitted txid/wtxid values."
     },
     {
       "section_key": "weight_accounting",


### PR DESCRIPTION
Closes #312

## Summary
- add a section-level txid/wtxid contract theorem over real preimage bytes and Merkle leaf domains
- restore `transaction_identifiers` from `cv_replay_only` to honest `machine_checked_contract`
- keep explicit limitations around witness-empty and cryptographic collision assumptions

## Validation
- export PATH="$HOME/.elan/bin:$PATH" && lake build
- scripts/dev-env.sh -- python3 tools/check_formal_coverage.py
- scripts/dev-env.sh -- python3 tools/check_formal_claims_lint.py
- scripts/dev-env.sh -- python3 tools/check_formal_refinement_bridge.py