### PR TITLE
formal: restore replay-domain non-cv coverage

### DIFF
--- a/RubinFormal/ReplayDomainBehavioral.lean
+++ b/RubinFormal/ReplayDomainBehavioral.lean
@@ -1,5 +1,6 @@
 import RubinFormal.UtxoBasicV1
 import RubinFormal.PrimitiveEncodingRoundtrip
+import RubinFormal.CriticalInvariants
 
 namespace RubinFormal
 open UtxoBasicV1
@@ -14,5 +15,25 @@ theorem u64le_zero_ne_one : encodeU64le 0 ≠ encodeU64le 1 := by native_decide
 
 /-- u64le encoding of 0 differs from max — covers full range. -/
 theorem u64le_zero_ne_max : encodeU64le 0 ≠ encodeU64le 18446744073709551615 := by native_decide
+
+/-- Parsing the same transaction bytes twice yields the same nonce, and a
+    duplicate nonce pair is therefore not replay-free. This ties the live
+    `parseTx` surface to the structural replay-domain invariant. -/
+theorem parsed_nonce_duplicate_not_replay_free (txBytes : Bytes)
+    (tx1 tx2 : Tx) (h1 : parseTx txBytes = .ok tx1) (h2 : parseTx txBytes = .ok tx2) :
+    ¬ nonceReplayFree [tx1.txNonce, tx2.txNonce] := by
+  have hNonce : tx1.txNonce = tx2.txNonce := parseTx_nonce_deterministic txBytes tx1 tx2 h1 h2
+  have hMem : tx1.txNonce ∈ [tx2.txNonce] := by
+    simp [hNonce]
+  simpa [hNonce] using duplicate_nonce_not_replay_free tx1.txNonce [tx2.txNonce] hMem
+
+/-- Section-level replay-domain contract: duplicate parsed nonces collapse to the
+    same replay-domain element and are therefore rejected by the structural
+    `nonceReplayFree` invariant. -/
+theorem replay_domain_nonce_contract (txBytes : Bytes)
+    (tx1 tx2 : Tx) (h1 : parseTx txBytes = .ok tx1) (h2 : parseTx txBytes = .ok tx2) :
+    tx1.txNonce = tx2.txNonce ∧ ¬ nonceReplayFree [tx1.txNonce, tx2.txNonce] := by
+  refine ⟨parseTx_nonce_deterministic txBytes tx1 tx2 h1 h2, ?_⟩
+  exact parsed_nonce_duplicate_not_replay_free txBytes tx1 tx2 h1 h2
 
 end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -686,14 +686,24 @@
       "section_heading": "## 1. Replay-Domain Checks (Normative)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.Conformance.cv_replay_vectors_pass"
+        "RubinFormal.Conformance.cv_replay_vectors_pass",
+        "RubinFormal.replay_domain_checks_proved",
+        "RubinFormal.parsed_nonce_duplicate_not_replay_free",
+        "RubinFormal.replay_domain_nonce_contract"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
-      "evidence_level": "cv_replay_only",
+      "theorem_files": {
+        "RubinFormal.replay_domain_checks_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
+        "RubinFormal.parsed_nonce_duplicate_not_replay_free": "rubin-formal/RubinFormal/ReplayDomainBehavioral.lean",
+        "RubinFormal.replay_domain_nonce_contract": "rubin-formal/RubinFormal/ReplayDomainBehavioral.lean"
+      },
+      "evidence_level": "machine_checked_contract",
       "limitations": [
-        "This section is evidenced by conformance vector replay only (native_decide). No structural or behavioral theorems are present. Coverage is bounded by the fixture set."
+        "This remains a contract-level row: the non-fixture theorem surface covers duplicate-nonce rejection and parseTx nonce determinism, while CV-REPLAY replay covers the shipped duplicate-set fixtures and block-basic replay vectors.",
+        "No universal theorem is claimed here for arbitrary multi-transaction blocks, chain-wide nonce indexing, or the exact executable duplicate-finder implementation over all possible nonce lists.",
+        "The section does not claim a full end-to-end proof that every block-level replay rejection in the live node is derived solely from `nonceReplayFree`; broader state-threading remains owned by the surrounding validation rows."
       ],
-      "notes": "CV replay pass only. No additional structural or behavioral theorems for this section."
+      "notes": "Section §1 is no longer replay-only: `replay_domain_checks_proved` restores the structural duplicate-nonce invariant from `PinnedSections/CriticalInvariants`, and `ReplayDomainBehavioral.lean` now adds live parseTx nonce-determinism + duplicate replay-domain contract theorems. CV-REPLAY remains the executable evidence for the current fixture set."
     },
     {
       "section_key": "utxo_state_model",


### PR DESCRIPTION
Closes #314

## Summary
- add live parseTx nonce-determinism plus duplicate replay-domain contract theorems
- restore `replay_domain_checks` from `cv_replay_only` to honest `machine_checked_contract`
- keep explicit limitations around chain-wide/state-threaded replay behavior

## Validation
- export PATH="$HOME/.elan/bin:$PATH" && lake build
- scripts/dev-env.sh -- python3 tools/check_formal_coverage.py
- scripts/dev-env.sh -- python3 tools/check_formal_claims_lint.py
- scripts/dev-env.sh -- python3 tools/check_formal_refinement_bridge.py