### PR TITLE
fix(ci): harden jsonrepair install in PR workflow

### DIFF
--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -52,15 +52,24 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: pr-diff
-      - name: Install jsonrepair
-        run: npm install jsonrepair@3.12.0
+      - name: Install jsonrepair in isolated directory
+        run: |
+          set -euo pipefail
+          mkdir -p "$JSONREPAIR_DIR"
+          cd "$JSONREPAIR_DIR"
+          npm init -y >/dev/null 2>&1
+          npm install --ignore-scripts --no-audit --no-fund --registry=https://registry.npmjs.org/ jsonrepair@3.12.0
+        env:
+          JSONREPAIR_DIR: ${{ runner.temp }}/jsonrepair
       - name: Run security review
         id: review
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          JSONREPAIR_DIR: ${{ runner.temp }}/jsonrepair
         with:
           script: |
             const fs = require('fs');
-            const { jsonrepair } = require('./node_modules/jsonrepair');
+            const { jsonrepair } = require(require('path').join(process.env.JSONREPAIR_DIR, 'node_modules', 'jsonrepair'));
             const path = require('path');
             const { execSync } = require('child_process');
             const rawOutputPath = 'deepseek-raw-output.txt';


### PR DESCRIPTION
### Motivation
- The PR workflow previously ran `npm install` in the checked-out PR workspace, which allowed PR-controlled `.npmrc` or package lifecycle scripts to influence install-time behavior and enabled CI code execution before the review step.
- The change isolates dependency installation and forces safer npm options to remove the supply-chain/code-execution vector in PR runs.

### Description
- Install `jsonrepair` into an isolated directory at `${{ runner.temp }}/jsonrepair` and expose that path to subsequent steps via the `JSONREPAIR_DIR` environment variable.
- Run `npm install` with `--ignore-scripts --no-audit --no-fund --registry=https://registry.npmjs.org/` to block lifecycle script execution and pin a trusted registry when installing `jsonrepair@3.12.0`.
- Update the `actions/github-script` step to require `jsonrepair` from `path.join(process.env.JSONREPAIR_DIR, 'node_modules', 'jsonrepair')` instead of `./node_modules` in the checked-out workspace.

### Testing
- Inspected the updated workflow file to confirm the installer now creates and uses `${{ runner.temp }}/jsonrepair` and that the review step reads the module from `JSONREPAIR_DIR`.
- Reviewed the workflow diff to verify the `--ignore-scripts` and explicit `--registry` flags are present on the `npm install` invocation.
- No automated unit tests were added for this CI configuration change; validation was performed by static review of the workflow and path/flag correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f8cc0fdc8322a54b388246e7188a)