### PR TITLE
test: verify DeepSeek workflow after fix (#343)

### DIFF
--- a/RubinFormal/ForkChoiceSelect.lean
+++ b/RubinFormal/ForkChoiceSelect.lean
@@ -219,3 +219,4 @@ forkSelect exactly models this: chainwork first, bytesLT tie-break.
 -/
 
 end RubinFormal
+-- DeepSeek workflow verification probe


### PR DESCRIPTION
Probe PR to verify DeepSeek review workflow runs after extracting inline script to external files. Delete after verification.