### PR TITLE
fix(ci): upsert review comments instead of creating duplicates (#335)

### DIFF
--- a/.github/workflows/formal-hygiene.yml
+++ b/.github/workflows/formal-hygiene.yml
@@ -100,10 +100,11 @@ jobs:
 
               try {
                 const marker = '### ⚠️ Formal Proof Hygiene';
-                const { data: comments } = await github.rest.issues.listComments({
+                const comments = await github.paginate(github.rest.issues.listComments, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
+                  per_page: 100,
                 });
                 const existing = comments.find(c =>
                   c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker)

--- a/.github/workflows/models-security-review.yml
+++ b/.github/workflows/models-security-review.yml
@@ -94,10 +94,11 @@ jobs:
             try { verdict = JSON.parse(review).verdict || 'UNKNOWN'; } catch(e) {}
             const marker = '### \uD83D\uDD12 Hostile Formal Review: DeepSeek-R1-0528';
             const body = `${marker}\n_Model: deepseek/DeepSeek-R1-0528_\n_Verdict: ${verdict}_\n\n\`\`\`json\n${review}\n\`\`\``;
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c =>
               c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker)


### PR DESCRIPTION
## Problem

Both `models-security-review.yml` and `formal-hygiene.yml` use `createComment` on every `synchronize` event, spamming duplicate review comments on the same PR.

## Fix

Find existing bot comment by heading marker (`### 🔒 Hostile Formal Review` / `### ⚠️ Formal Proof Hygiene`), update in place if found, create only if not.

Pattern: `listComments` → find by `user.login === github-actions[bot]` + `body.startsWith(marker)` → `updateComment` or `createComment`.

## Files changed

- `.github/workflows/models-security-review.yml` — DeepSeek review comment
- `.github/workflows/formal-hygiene.yml` — premise-smell comment

Closes #335
