### PR TITLE
fix(registry): standardize all paths to rubin-formal/ prefix (#336)

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -1144,7 +1144,7 @@
         "RubinFormal.Refinement.ParallelEquivalence.reducer_permutation_invariant",
         "RubinFormal.Refinement.ParallelEquivalence.precompute_enables_reorder"
       ],
-      "file": "RubinFormal/Refinement/ParallelEquivalence.lean",
+      "file": "rubin-formal/RubinFormal/Refinement/ParallelEquivalence.lean",
       "notes": "Helper-level bridge for the live parallel signature queue contract. The counted surface now closes only the accept/reject behavior that Go SigCheckQueue.Flush actually promises: success iff every queued signature verifies, rejection iff any queued signature fails. The row no longer counts cursor/signature purity wrappers or corollary wrappers as substantive evidence.",
       "limitations": [
         "This row does not claim an end-to-end theorem for ConnectBlockBasicInMemoryAtHeight versus ConnectBlockParallelSigVerify over the full block pipeline.",
@@ -1215,11 +1215,11 @@
         "RubinFormal.NativeSuiteRotation.fi_rot_02_phase_partition",
         "RubinFormal.NativeSuiteRotation.fi_rot_02_phases_exclusive"
       ],
-      "file": "RubinFormal/NativeSuiteRotation.lean",
+      "file": "rubin-formal/RubinFormal/NativeSuiteRotation.lean",
       "theorem_files": {
-        "RubinFormal.NativeSuiteRotation.fi_rot_01_descriptor_unique": "RubinFormal/NativeSuiteRotation.lean",
-        "RubinFormal.NativeSuiteRotation.fi_rot_02_phase_partition": "RubinFormal/NativeSuiteRotation.lean",
-        "RubinFormal.NativeSuiteRotation.fi_rot_02_phases_exclusive": "RubinFormal/NativeSuiteRotation.lean"
+        "RubinFormal.NativeSuiteRotation.fi_rot_01_descriptor_unique": "rubin-formal/RubinFormal/NativeSuiteRotation.lean",
+        "RubinFormal.NativeSuiteRotation.fi_rot_02_phase_partition": "rubin-formal/RubinFormal/NativeSuiteRotation.lean",
+        "RubinFormal.NativeSuiteRotation.fi_rot_02_phases_exclusive": "rubin-formal/RubinFormal/NativeSuiteRotation.lean"
       },
       "notes": "FI-ROT-01: at-most-one active descriptor via state-machine induction (no axioms). FI-ROT-02: five-phase exhaustive partition with mutual exclusion (10 pairwise contradictions). Conformance replay: 6 cutoff + 5 sunset vectors structurally verified. Model-level proofs on Lean definitions; no Go/Rust implementation exists yet for rotation, so no implementation bridge.",
       "limitations": [

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -241,7 +241,7 @@
       "op": "native_suite_rotation",
       "gate": "FI-ROT-01 + FI-ROT-02",
       "model_theorem": "RubinFormal.NativeSuiteRotation.fi_rot_01_descriptor_unique",
-      "lean_file": "RubinFormal/NativeSuiteRotation.lean",
+      "lean_file": "rubin-formal/RubinFormal/NativeSuiteRotation.lean",
       "supporting_theorems": [
         "RubinFormal.NativeSuiteRotation.fi_rot_02_phase_partition",
         "RubinFormal.NativeSuiteRotation.fi_rot_02_phases_exclusive",

--- a/tools/check_formal_registry_truth.py
+++ b/tools/check_formal_registry_truth.py
@@ -11,7 +11,6 @@ from typing import Optional, Tuple
 
 
 REPO_PREFIX = "rubin-formal/"
-MODULE_PREFIX = "RubinFormal/"
 
 # Intentionally narrow shared-op parity scope after Q-FORMAL-REGISTRY-EVIDENCE-LEVEL-ALIGN-01.
 # `retarget_v1` and `fork_choice_select` remain honest supplemental bridge lanes whose
@@ -184,9 +183,10 @@ def rel_repo_path(repo_root: Path, path: Path) -> str:
 def lean_repo_path(repo_root: Path, rel_path: str) -> Path:
     if rel_path.startswith(REPO_PREFIX):
         return repo_root / rel_path[len(REPO_PREFIX) :]
-    if rel_path.startswith(MODULE_PREFIX):
-        return repo_root / rel_path
-    raise ValueError(f"unsupported non-repo path in registry: {rel_path}")
+    raise ValueError(
+        f"non-canonical path in registry: {rel_path!r} "
+        f"(must start with {REPO_PREFIX!r})"
+    )
 
 
 def try_lean_repo_path(repo_root: Path, rel_path: str) -> Optional[Path]:
@@ -197,10 +197,13 @@ def try_lean_repo_path(repo_root: Path, rel_path: str) -> Optional[Path]:
 
 
 def olean_path(repo_root: Path, rel_path: str) -> Path:
-    normalized = rel_path
-    if normalized.startswith(REPO_PREFIX):
-        normalized = normalized[len(REPO_PREFIX) :]
-    if not normalized.startswith(MODULE_PREFIX) or not normalized.endswith(".lean"):
+    if not rel_path.startswith(REPO_PREFIX):
+        raise ValueError(
+            f"non-canonical path in registry: {rel_path!r} "
+            f"(must start with {REPO_PREFIX!r})"
+        )
+    normalized = rel_path[len(REPO_PREFIX) :]
+    if not normalized.startswith("RubinFormal/") or not normalized.endswith(".lean"):
         raise ValueError(f"registered file is outside RubinFormal build graph surface: {rel_path}")
     suffix = normalized[: -len(".lean")]
     return repo_root / ".lake" / "build" / "lib" / f"{suffix}.olean"


### PR DESCRIPTION
Normalize 5 non-canonical `RubinFormal/` paths to `rubin-formal/RubinFormal/` in registry JSON files and tighten the truth-checker to reject bare `RubinFormal/` paths.

## Changes

**proof_coverage.json** — 2 entries normalized:
- `RubinFormal/Refinement/ParallelEquivalence.lean` → `rubin-formal/RubinFormal/Refinement/ParallelEquivalence.lean`
- `RubinFormal/NativeSuiteRotation.lean` → `rubin-formal/RubinFormal/NativeSuiteRotation.lean` (file + 3 theorem_files)

**refinement_bridge.json** — 1 entry normalized:
- `RubinFormal/NativeSuiteRotation.lean` → `rubin-formal/RubinFormal/NativeSuiteRotation.lean`

**tools/check_formal_registry_truth.py**:
- Remove `MODULE_PREFIX` dual-path toleration
- `lean_repo_path()` and `olean_path()` now reject non-canonical paths with clear error messages
- Truth-checker validates: 56 files, 457 coverage refs, 131 bridge refs, 3 parity rows — all pass

Closes #336