### PR TITLE
fix(formal): cold-build fix for TxWireTxBodyContract

### DIFF
--- a/RubinFormal/TxWireTxBodyContract.lean
+++ b/RubinFormal/TxWireTxBodyContract.lean
@@ -1,6 +1,6 @@
 import RubinFormal.TxWireTxFinalizeContract
 
-set_option maxHeartbeats 50000000
+set_option maxHeartbeats 8000000
 set_option maxRecDepth 8192
 
 namespace RubinFormal
@@ -23,8 +23,7 @@ private theorem parseTxAfterOutputs_after_pre
             tx.daPayload,
           off := pre.size } =
       Except.ok tx := by
-  rcases h with
-    ⟨_, _, _, _, _, _, _, hLock, _, _, _, _, _, _⟩
+  have hLock := h.2.2.2.2.2.2.2.1
   let postLock : Bytes :=
     tx.daCoreBytes ++ serializeWitness tx.witness ++ RubinFormal.WireEnc.compactSize tx.daPayloadLen ++
       tx.daPayload
@@ -50,9 +49,12 @@ private theorem parseTxAfterOutputs_after_pre
               serializeWitness tx.witness ++ RubinFormal.WireEnc.compactSize tx.daPayloadLen ++
               tx.daPayload,
             off := (pre ++ RubinFormal.WireEnc.u32le tx.locktime).size } =
-        Except.ok tx :=
-    parseTxAfterLock_after_pre (pre := pre ++ RubinFormal.WireEnc.u32le tx.locktime) tx h
+        Except.ok tx := by
+    have h_raw := parseTxAfterLock_after_pre (pre := pre ++ RubinFormal.WireEnc.u32le tx.locktime) tx h
+    simp only [← cursor_bytes_left_assoc] at h_raw
+    exact h_raw
   unfold parseTxAfterOutputs
+  simp only [postLock, ← cursor_bytes_left_assoc] at hLockRead
   rw [hLockRead]
   simpa [postLock, ByteArray.size_append, Nat.add_assoc] using hAfterLock
 
@@ -70,8 +72,8 @@ private theorem parseTxAfterInputs_after_pre
             RubinFormal.WireEnc.compactSize tx.daPayloadLen ++ tx.daPayload,
           off := pre.size } =
       Except.ok tx := by
-  rcases h with
-    ⟨_, _, _, _, _, hOutputsWF, hOutputsLen, _, _, _, _, _, _, _⟩
+  have hOutputsWF := h.2.2.2.2.2.1
+  have hOutputsLen := h.2.2.2.2.2.2.1
   let outCountBytes : Bytes := RubinFormal.WireEnc.compactSize tx.outputs.length
   let postOutCount : Bytes :=
     serializeOutputs tx.outputs ++ RubinFormal.WireEnc.u32le tx.locktime ++ tx.daCoreBytes ++
@@ -97,13 +99,14 @@ private theorem parseTxAfterInputs_after_pre
           (tx.outputs,
             { bs := pre ++ outCountBytes ++ postOutCount,
               off := pre.size + outCountBytes.size + (serializeOutputs tx.outputs).size }) := by
-    simpa [outCountBytes, postOutCount, ByteArray.size_append, Nat.add_assoc] using
-      (parseOutputs_serializeOutputs_between
+    have h_raw := (parseOutputs_serializeOutputs_between
         (pre := pre ++ outCountBytes)
         (outs := tx.outputs)
         (post := RubinFormal.WireEnc.u32le tx.locktime ++ tx.daCoreBytes ++ serializeWitness tx.witness ++
           RubinFormal.WireEnc.compactSize tx.daPayloadLen ++ tx.daPayload)
         hOutputsWF)
+    simp only [outCountBytes, postOutCount, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at h_raw ⊢
+    exact h_raw
   have hAfterOutputs :
       parseTxAfterOutputs
           ((pre ++ outCountBytes) ++ serializeOutputs tx.outputs ++ RubinFormal.WireEnc.u32le tx.locktime ++
@@ -115,11 +118,14 @@ private theorem parseTxAfterInputs_after_pre
               tx.daPayload,
             off := (pre ++ outCountBytes).size + (serializeOutputs tx.outputs).size } =
         Except.ok tx := by
-    simpa [ByteArray.size_append, Nat.add_assoc] using
-      (parseTxAfterOutputs_after_pre (pre := pre ++ outCountBytes ++ serializeOutputs tx.outputs) tx h)
+    have h_raw := parseTxAfterOutputs_after_pre (pre := pre ++ outCountBytes ++ serializeOutputs tx.outputs) tx h
+    simp only [outCountBytes, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at h_raw ⊢
+    exact h_raw
   unfold parseTxAfterInputs
+  simp only [outCountBytes, postOutCount, ← cursor_bytes_left_assoc] at hOutCountRead
   rw [hOutCountRead]
   simp
+  simp only [outCountBytes, postOutCount, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at hOutputsRead
   rw [hOutputsRead]
   simpa [outCountBytes, postOutCount, ByteArray.size_append, Nat.add_assoc] using hAfterOutputs
 
@@ -132,8 +138,8 @@ private theorem parseTxAfterNonce_after_pre
         tx.version tx.txKind tx.txNonce
         { bs := pre ++ serializeTxAfterNonce tx, off := pre.size } =
       Except.ok tx := by
-  rcases h with
-    ⟨_, _, _, hInputsWF, hInputsLen, _, _, _, _, _, _, _, _, _⟩
+  have hInputsWF := h.2.2.2.1
+  have hInputsLen := h.2.2.2.2.1
   let inCountBytes : Bytes := RubinFormal.WireEnc.compactSize tx.inputs.length
   let postInCount : Bytes :=
     serializeInputs tx.inputs ++ RubinFormal.WireEnc.compactSize tx.outputs.length ++
@@ -160,14 +166,15 @@ private theorem parseTxAfterNonce_after_pre
           (tx.inputs,
             { bs := pre ++ inCountBytes ++ postInCount,
               off := pre.size + inCountBytes.size + (serializeInputs tx.inputs).size }) := by
-    simpa [inCountBytes, postInCount, serializeTxAfterNonce, ByteArray.size_append, Nat.add_assoc] using
-      (parseInputs_serializeInputs_between
+    have h_raw := (parseInputs_serializeInputs_between
         (pre := pre ++ inCountBytes)
         (ins := tx.inputs)
         (post := RubinFormal.WireEnc.compactSize tx.outputs.length ++ serializeOutputs tx.outputs ++
           RubinFormal.WireEnc.u32le tx.locktime ++ tx.daCoreBytes ++ serializeWitness tx.witness ++
           RubinFormal.WireEnc.compactSize tx.daPayloadLen ++ tx.daPayload)
         hInputsWF)
+    simp only [inCountBytes, postInCount, serializeTxAfterNonce, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at h_raw ⊢
+    exact h_raw
   have hAfterInputs :
       parseTxAfterInputs
           ((pre ++ inCountBytes) ++ serializeInputs tx.inputs ++ RubinFormal.WireEnc.compactSize tx.outputs.length ++
@@ -179,14 +186,24 @@ private theorem parseTxAfterNonce_after_pre
               serializeWitness tx.witness ++ RubinFormal.WireEnc.compactSize tx.daPayloadLen ++ tx.daPayload,
             off := (pre ++ inCountBytes).size + (serializeInputs tx.inputs).size } =
         Except.ok tx := by
-    simpa [ByteArray.size_append, Nat.add_assoc] using
-      (parseTxAfterInputs_after_pre (pre := pre ++ inCountBytes ++ serializeInputs tx.inputs) tx h)
-  unfold parseTxAfterNonce
+    have h_raw := parseTxAfterInputs_after_pre (pre := pre ++ inCountBytes ++ serializeInputs tx.inputs) tx h
+    simp only [inCountBytes, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at h_raw ⊢
+    exact h_raw
+  unfold parseTxAfterNonce serializeTxAfterNonce
+  simp only [← cursor_bytes_left_assoc]
+  simp only [inCountBytes, postInCount, ← cursor_bytes_left_assoc] at hInCountRead
   rw [hInCountRead]
   simp
+  simp only [inCountBytes, postInCount, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at hInputsRead
   rw [hInputsRead]
-  simpa [inCountBytes, postInCount, serializeTxAfterNonce, ByteArray.size_append, Nat.add_assoc] using
-    hAfterInputs
+  simp only [inCountBytes, postInCount, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at hAfterInputs ⊢
+  exact hAfterInputs
+
+private theorem bytes_empty_append (bs : Bytes) : ByteArray.empty ++ bs = bs := by
+  apply ByteArray.ext
+  simp [ByteArray.append_data, ByteArray.empty_data, Array.nil_append]
+
+private theorem bytes_empty_size : ByteArray.empty.size = 0 := rfl
 
 theorem parseTxAfterNonce_serializeTx_roundtrip
     (tx : Tx)
@@ -194,7 +211,9 @@ theorem parseTxAfterNonce_serializeTx_roundtrip
     parseTxAfterNonce (serializeTxAfterNonce tx) tx.version tx.txKind tx.txNonce
         { bs := serializeTxAfterNonce tx, off := 0 } =
       Except.ok tx := by
-  simpa using parseTxAfterNonce_after_pre (pre := ByteArray.empty) tx h
+  have h_raw := parseTxAfterNonce_after_pre (pre := ByteArray.empty) tx h
+  simp only [bytes_empty_append, bytes_empty_size] at h_raw
+  exact h_raw
 
 end UtxoBasicV1
 


### PR DESCRIPTION
## Summary

- Replace all diverging `simpa` calls with targeted `simp only` in TxWireTxBodyContract.lean
- `simpa` with let-variable unfolding caused infinite whnf normalization on ByteArray concatenation chains during cold builds (olean cache masked the issue)
- Add `bytes_empty_append` helper via `ByteArray.ext` + `Array.nil_append`
- Reduce `maxHeartbeats` from 50M to 8M (cold build verified locally)

## Pattern applied

- Theorems 1–3: `simp only [letVars, ← cursor_bytes_left_assoc, ByteArray.size_append, Nat.add_assoc] at h_raw ⊢; exact h_raw`
- Theorem 4: `bytes_empty_append` + `bytes_empty_size` to eliminate `ByteArray.empty ++ bs` and `.size = 0`

## Test plan

- [x] Cold build TxWireTxBodyContract.lean (oleans deleted, 8M heartbeats)
- [ ] CI green on full lean build