### PR TITLE
formal: propagate vault threshold errors generically

### DIFF
--- a/RubinFormal/UtxoApplyGenesisV1.lean
+++ b/RubinFormal/UtxoApplyGenesisV1.lean
@@ -329,6 +329,21 @@ theorem vault_bad_sponsor (lids : List Bytes) (covs : List Nat) (vOwnLid : Bytes
     .error "TX_ERR_VAULT_FEE_SPONSOR_FORBIDDEN" := by
   simp [validateVaultSpend, hBad]
 
+/-- Generic live propagation bridge: once owner-auth and sponsor checks pass,
+    any error returned by `validateThresholdSigSpendNoCrypto` is forwarded
+    unchanged through `validateVaultSpend`. -/
+theorem vault_threshold_error_propagates
+    (lids : List Bytes) (covs : List Nat) (vOwnLid : Bytes)
+    (vKeys : List Bytes) (vThr : Nat) (vWit : List UtxoBasicV1.WitnessItem) (h : Nat)
+    (outs : List UtxoBasicV1.TxOut) (wl : List Bytes)
+    (e : String)
+    (hOk : (List.zip covs lids).all (fun (cov, lid) =>
+      cov == CovenantGenesisV1.COV_TYPE_VAULT || lid == vOwnLid) = true)
+    (hSig : validateThresholdSigSpendNoCrypto vKeys vThr vWit h "CORE_VAULT" = .error e) :
+    validateVaultSpend true lids covs vOwnLid vKeys vThr vWit h outs wl =
+    .error e := by
+  simp [validateVaultSpend, hOk, hSig]
+
 /-- Bad whitelist → TX_ERR_VAULT_OUTPUT_NOT_WHITELISTED. -/
 theorem vault_bad_whitelist (lids : List Bytes) (covs : List Nat) (vOwnLid : Bytes)
     (vKeys : List Bytes) (vThr : Nat) (vWit : List UtxoBasicV1.WitnessItem) (h : Nat)


### PR DESCRIPTION
## Summary
- add a generic live propagation theorem for `validateVaultSpend`
- prove that any inner `validateThresholdSigSpendNoCrypto` error is forwarded unchanged once owner-auth and sponsor checks pass
- keep this as a narrow post-#381 follow-up without new queue canonization

## Validation
- `lake build RubinFormal.UtxoApplyGenesisV1`
- `lake build`
- `python3 tools/check_formal_registry_truth.py`

## Context
Post-merge follow-up to #381 to finish the remaining outer vault error-propagation surface.