### PR TITLE
formal: align structural rules registry with vault follow-ups

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -691,7 +691,11 @@
         "RubinFormal.threshold_unknown_suite_anywhere_rejected_universal",
         "RubinFormal.threshold_hash_mismatch_anywhere_rejected",
         "RubinFormal.threshold_below_required_count_rejected",
-        "RubinFormal.threshold_required_count_accepts"
+        "RubinFormal.threshold_required_count_accepts",
+        "RubinFormal.vault_threshold_hash_mismatch_anywhere_rejected",
+        "RubinFormal.vault_threshold_below_required_count_rejected",
+        "RubinFormal.vault_threshold_required_count_accepts",
+        "RubinFormal.UtxoApplyGenesisV1.vault_threshold_error_propagates"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -712,9 +716,13 @@
         "RubinFormal.threshold_unknown_suite_anywhere_rejected_universal": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
         "RubinFormal.threshold_hash_mismatch_anywhere_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
         "RubinFormal.threshold_below_required_count_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
-        "RubinFormal.threshold_required_count_accepts": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean"
+        "RubinFormal.threshold_required_count_accepts": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.vault_threshold_hash_mismatch_anywhere_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.vault_threshold_below_required_count_rejected": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.vault_threshold_required_count_accepts": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.UtxoApplyGenesisV1.vault_threshold_error_propagates": "rubin-formal/RubinFormal/UtxoApplyGenesisV1.lean"
       },
-      "notes": "Universal behavioral theorems on live validateWitnessItemLengths (R1-R6) and validateThresholdSigSpendNoCrypto threshold semantics. Complete partition of validateWitnessItemLengths plus live threshold wrong-count rejection, unknown-suite-anywhere rejection, hash-mismatch-anywhere rejection, below-threshold rejection, and threshold-satisfied acceptance on the zipped witness/key loop. Concrete regression tests retained.",
+      "notes": "Universal behavioral theorems on live validateWitnessItemLengths (R1-R6), live validateThresholdSigSpendNoCrypto threshold semantics, and the outer live validateVaultSpend propagation layer for the pre-rotation noCrypto vault path. Complete partition of validateWitnessItemLengths plus live threshold wrong-count rejection, unknown-suite-anywhere rejection, hash-mismatch-anywhere rejection, below-threshold rejection, threshold-satisfied acceptance on the zipped witness/key loop, and outer vault propagation for generic inner errors, hash-mismatch, below-threshold rejection, and threshold-satisfied acceptance. Concrete regression tests retained.",
       "limitations": [],
       "evidence_level": "machine_checked_universal"
     },


### PR DESCRIPTION
## Summary
- update `transaction_structural_rules` registry coverage after merged formal follow-ups #381 and #382
- add outer vault theorem refs and theorem_files entries
- align the machine-readable notes with the already-merged proof surface

## Validation
- `lake build`
- `python3 tools/check_formal_registry_truth.py`

## Scope
Registry-only alignment. No new theorem code and no new queue canonization.