### PR TITLE
formal: constrain weight_accounting universal bridge

### DIFF
--- a/RubinFormal/TxWeightBehavioral.lean
+++ b/RubinFormal/TxWeightBehavioral.lean
@@ -312,8 +312,8 @@ theorem txWeightAndStats_error_empty :
     txWeightAndStats (RubinFormal.bytes #[]) = .error "TX_ERR_PARSE" := by
   unfold txWeightAndStats parseTxHeader; simp [Wire.Cursor.getU32le?]; rfl
 
-/-- LIVE: txWeightAndStats rejects input shorter than 5 bytes. -/
-theorem txWeightAndStats_error_short (b0 b1 b2 b3 : UInt8) :
+/-- LIVE: txWeightAndStats rejects 4-byte input (nonce parsed but no kind byte). -/
+theorem txWeightAndStats_error_4bytes (b0 b1 b2 b3 : UInt8) :
     txWeightAndStats (RubinFormal.bytes #[b0, b1, b2, b3]) = .error "TX_ERR_PARSE" := by
   unfold txWeightAndStats parseTxHeader; simp [Wire.Cursor.getU32le?, Wire.Cursor.getU8?]; rfl
 

--- a/RubinFormal/TxWeightBehavioral.lean
+++ b/RubinFormal/TxWeightBehavioral.lean
@@ -308,6 +308,36 @@ theorem txWeightAndStats_ok_weight_eq (tx : Bytes) (stats : WeightStats)
     · obtain ⟨daLen, hw⟩ := finalizeTxWeight_ok _ _ _ _ _ _ _ h
       exact ⟨_, daLen, _, hw⟩
 
+/-- LIVE: Full Except-chain proof with parse-constrained witnesses.
+    This strengthens `txWeightAndStats_ok_weight_eq` by recording the exact
+    successful parse chain that produced the weight inputs. -/
+theorem txWeightAndStats_ok_weight_eq_constrained (tx : Bytes) (stats : WeightStats)
+    (h : txWeightAndStats tx = .ok stats) :
+    ∃ (txKind : Nat) (c1 : Wire.Cursor) (baseSize anchorBytes : Nat)
+      (ws : WitnessSectionResult) (c2 : Wire.Cursor) (daLen : Nat),
+      parseTxHeader tx = .ok (txKind, c1) ∧
+      parseTxBody txKind c1 = .ok (baseSize, anchorBytes, ws, c2) ∧
+      finalizeTxWeight tx txKind baseSize anchorBytes ws c2 = .ok stats ∧
+      stats.weight = computeWeight baseSize (ws.endOff - ws.startOff)
+        (compactSizeLen daLen + daLen)
+        (ws.mlCount * VERIFY_COST_ML_DSA_87 + ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE) := by
+  unfold txWeightAndStats at h
+  cases hHeader : parseTxHeader tx with
+  | error e =>
+      simp only [bind, Except.bind, hHeader] at h
+  | ok header =>
+      rcases header with ⟨txKind, c1⟩
+      cases hBody : parseTxBody txKind c1 with
+      | error e =>
+          simp only [bind, Except.bind, hHeader, hBody] at h
+      | ok body =>
+          rcases body with ⟨baseSize, anchorBytes, ws, c2⟩
+          simp only [bind, Except.bind, hHeader, hBody] at h
+          have hFinal : finalizeTxWeight tx txKind baseSize anchorBytes ws c2 = .ok stats := by
+            exact h
+          obtain ⟨daLen, hw⟩ := finalizeTxWeight_ok tx txKind baseSize anchorBytes ws c2 stats hFinal
+          exact ⟨txKind, c1, baseSize, anchorBytes, ws, c2, daLen, rfl, hBody, hFinal, hw⟩
+
 /-- LIVE: weightTail success implies weight > 0 (non-vacuous, uses h). -/
 theorem weightTail_weight_pos (tx : Bytes) (txKind baseSize anchorBytes daLen : Nat)
     (ws : WitnessSectionResult) (c10 : Wire.Cursor) (stats : WeightStats)
@@ -341,7 +371,7 @@ theorem finalizeTxWeight_weight_pos (tx : Bytes) (txKind baseSize anchorBytes : 
 /-- LIVE: txWeightAndStats success implies weight > 0.
     Non-vacuous: 0 is explicitly excluded from .ok results because
     compactSizeLen ≥ 1 guarantees weight ≥ 1 in every .ok path.
-    Empty/short inputs produce .error, not .ok. -/
+    Empty input and 4-byte input are proved to reject, so `.ok` is non-trivial. -/
 theorem txWeightAndStats_weight_pos (tx : Bytes) (stats : WeightStats)
     (h : txWeightAndStats tx = .ok stats) :
     stats.weight > 0 := by

--- a/RubinFormal/TxWeightBehavioral.lean
+++ b/RubinFormal/TxWeightBehavioral.lean
@@ -253,59 +253,60 @@ The live function `txWeightAndStats` is composed from `parseTxHeader → parseTx
 finalizeTxWeight`. Each sub-function has ≤8 match/if points, making the full
 case-analysis proof tractable without kernel overflow. -/
 
-/-- LIVE: weightTail success → weight = computeWeight. -/
+/-- LIVE: weightTail success → weight = computeWeight with CONCRETE witnesses.
+    All components are determined by function arguments — zero unconstrained existentials. -/
 theorem weightTail_ok (tx : Bytes) (txKind baseSize anchorBytes daLen : Nat)
     (ws : WitnessSectionResult) (c10 : Wire.Cursor) (stats : WeightStats)
     (h : weightTail tx txKind baseSize anchorBytes daLen ws c10 = .ok stats) :
-    ∃ (witnessSize daSize sigCost : Nat),
-      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+    stats.weight = computeWeight baseSize (ws.endOff - ws.startOff)
+      (compactSizeLen daLen + daLen)
+      (ws.mlCount * VERIFY_COST_ML_DSA_87 + ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE) := by
   unfold weightTail at h
-  split at h
-  · exact Except.noConfusion h
-  · split at h
-    · exact (nomatch h)
-    · injection h with h; subst h; exact ⟨_, _, _, rfl⟩
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact (nomatch h)
+    · injection h with h; subst h; rfl
 
-/-- LIVE: finalizeTxWeight success → weight = computeWeight. -/
+/-- LIVE: finalizeTxWeight success → weight = computeWeight with parse-derived witnesses.
+    Only daLen is existential (parsed from cursor). witnessSize and sigCost are concrete
+    from the WitnessSectionResult argument. -/
 theorem finalizeTxWeight_ok (tx : Bytes) (txKind baseSize anchorBytes : Nat)
     (ws : WitnessSectionResult) (c : Wire.Cursor) (stats : WeightStats)
     (h : finalizeTxWeight tx txKind baseSize anchorBytes ws c = .ok stats) :
-    ∃ (witnessSize daSize sigCost : Nat),
-      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+    ∃ daLen : Nat,
+      stats.weight = computeWeight baseSize (ws.endOff - ws.startOff)
+        (compactSizeLen daLen + daLen)
+        (ws.mlCount * VERIFY_COST_ML_DSA_87 + ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE) := by
   unfold finalizeTxWeight at h
-  split at h
-  · exact Except.noConfusion h
-  · split at h
-    · exact (nomatch h)
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact (nomatch h)
     · split at h
+      · split at h; · exact (nomatch h)
+        · exact ⟨_, weightTail_ok _ _ _ _ _ _ _ _ h⟩
       · split at h
-        · exact (nomatch h)
-        · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
-      · split at h
-        · split at h
-          · exact (nomatch h)
-          · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
-        · split at h
-          · exact (nomatch h)
-          · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
+        · split at h; · exact (nomatch h)
+          · exact ⟨_, weightTail_ok _ _ _ _ _ _ _ _ h⟩
+        · split at h; · exact (nomatch h)
+          · exact ⟨_, weightTail_ok _ _ _ _ _ _ _ _ h⟩
 
-/-- LIVE: Full Except-chain proof. If txWeightAndStats succeeds,
-    weight = computeWeight(baseSize, witnessSize, daSize, sigCost)
-    for specific values determined by the parse chain.
-    This is the key universal theorem connecting the live function
-    to the behavioral formula decomposition. -/
+/-- LIVE: Full Except-chain proof with constrained witnesses.
+    If txWeightAndStats succeeds, weight = computeWeight where:
+    - baseSize = cursor offset after parsing header+inputs+outputs+DA core (existential)
+    - witnessSize = ws.endOff - ws.startOff (concrete from WitnessSectionResult)
+    - daSize = compactSizeLen daLen + daLen (existential daLen from DA manifest parse)
+    - sigCost = mlCount * 8 + unknownCount * 64 (concrete from WitnessSectionResult)
+    Only baseSize and daLen are existential — both parse-derived, not arbitrary. -/
 theorem txWeightAndStats_ok_weight_eq (tx : Bytes) (stats : WeightStats)
     (h : txWeightAndStats tx = .ok stats) :
-    ∃ (baseSize witnessSize daSize sigCost : Nat),
-      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+    ∃ (baseSize daLen : Nat) (ws : WitnessSectionResult),
+      stats.weight = computeWeight baseSize (ws.endOff - ws.startOff)
+        (compactSizeLen daLen + daLen)
+        (ws.mlCount * VERIFY_COST_ML_DSA_87 + ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE) := by
   unfold txWeightAndStats at h
   simp only [bind, Except.bind] at h
-  split at h
-  · exact Except.noConfusion h
-  · split at h
-    · exact Except.noConfusion h
-    · obtain ⟨ws, ds, sc, hw⟩ := finalizeTxWeight_ok tx _ _ _ _ _ stats h
-      exact ⟨_, ws, ds, sc, hw⟩
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact Except.noConfusion h
+    · obtain ⟨daLen, hw⟩ := finalizeTxWeight_ok _ _ _ _ _ _ _ h
+      exact ⟨_, daLen, _, hw⟩
 
 /-- LIVE: weightTail success implies weight > 0 (non-vacuous, uses h). -/
 theorem weightTail_weight_pos (tx : Bytes) (txKind baseSize anchorBytes daLen : Nat)

--- a/RubinFormal/TxWeightBehavioral.lean
+++ b/RubinFormal/TxWeightBehavioral.lean
@@ -244,10 +244,77 @@ theorem weight_cv_replay_pass :
   - **Suite-aware model**: `WeightSuiteAware.weight_suite_aware_correct`
     covers post-rotation registry-based cost lookup
 
-  Remaining non-claim: full end-to-end monadic parse-to-weight theorem
-  (threading through Option/Except chain of txWeightAndStats) is deliberately
-  not attempted — the behavioral decomposition + CV replay combination provides
-  equivalent assurance without brittle coupling to internal parser state.
+  Full Except-chain proof now machine-checked via txWeightAndStats_ok_weight_eq.
 -/
+
+/-! ## LIVE: Full Except-chain theorems on txWeightAndStats
+
+The live function `txWeightAndStats` is composed from `parseTxHeader → parseTxBody →
+finalizeTxWeight`. Each sub-function has ≤8 match/if points, making the full
+case-analysis proof tractable without kernel overflow. -/
+
+/-- LIVE: weightTail success → weight = computeWeight. -/
+theorem weightTail_ok (tx : Bytes) (txKind baseSize anchorBytes daLen : Nat)
+    (ws : WitnessSectionResult) (c10 : Wire.Cursor) (stats : WeightStats)
+    (h : weightTail tx txKind baseSize anchorBytes daLen ws c10 = .ok stats) :
+    ∃ (witnessSize daSize sigCost : Nat),
+      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+  unfold weightTail at h
+  split at h
+  · exact Except.noConfusion h
+  · split at h
+    · exact (nomatch h)
+    · injection h with h; subst h; exact ⟨_, _, _, rfl⟩
+
+/-- LIVE: finalizeTxWeight success → weight = computeWeight. -/
+theorem finalizeTxWeight_ok (tx : Bytes) (txKind baseSize anchorBytes : Nat)
+    (ws : WitnessSectionResult) (c : Wire.Cursor) (stats : WeightStats)
+    (h : finalizeTxWeight tx txKind baseSize anchorBytes ws c = .ok stats) :
+    ∃ (witnessSize daSize sigCost : Nat),
+      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+  unfold finalizeTxWeight at h
+  split at h
+  · exact Except.noConfusion h
+  · split at h
+    · exact (nomatch h)
+    · split at h
+      · split at h
+        · exact (nomatch h)
+        · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
+      · split at h
+        · split at h
+          · exact (nomatch h)
+          · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
+        · split at h
+          · exact (nomatch h)
+          · exact weightTail_ok tx txKind baseSize anchorBytes _ ws _ stats h
+
+/-- LIVE: Full Except-chain proof. If txWeightAndStats succeeds,
+    weight = computeWeight(baseSize, witnessSize, daSize, sigCost)
+    for specific values determined by the parse chain.
+    This is the key universal theorem connecting the live function
+    to the behavioral formula decomposition. -/
+theorem txWeightAndStats_ok_weight_eq (tx : Bytes) (stats : WeightStats)
+    (h : txWeightAndStats tx = .ok stats) :
+    ∃ (baseSize witnessSize daSize sigCost : Nat),
+      stats.weight = computeWeight baseSize witnessSize daSize sigCost := by
+  unfold txWeightAndStats at h
+  simp only [bind, Except.bind] at h
+  split at h
+  · exact Except.noConfusion h
+  · split at h
+    · exact Except.noConfusion h
+    · obtain ⟨ws, ds, sc, hw⟩ := finalizeTxWeight_ok tx _ _ _ _ _ stats h
+      exact ⟨_, ws, ds, sc, hw⟩
+
+/-- LIVE: txWeightAndStats rejects empty input. -/
+theorem txWeightAndStats_error_empty :
+    txWeightAndStats (RubinFormal.bytes #[]) = .error "TX_ERR_PARSE" := by
+  unfold txWeightAndStats parseTxHeader; simp [Wire.Cursor.getU32le?]; rfl
+
+/-- LIVE: txWeightAndStats rejects input shorter than 5 bytes. -/
+theorem txWeightAndStats_error_short (b0 b1 b2 b3 : UInt8) :
+    txWeightAndStats (RubinFormal.bytes #[b0, b1, b2, b3]) = .error "TX_ERR_PARSE" := by
+  unfold txWeightAndStats parseTxHeader; simp [Wire.Cursor.getU32le?, Wire.Cursor.getU8?]; rfl
 
 end RubinFormal

--- a/RubinFormal/TxWeightBehavioral.lean
+++ b/RubinFormal/TxWeightBehavioral.lean
@@ -307,6 +307,49 @@ theorem txWeightAndStats_ok_weight_eq (tx : Bytes) (stats : WeightStats)
     · obtain ⟨ws, ds, sc, hw⟩ := finalizeTxWeight_ok tx _ _ _ _ _ stats h
       exact ⟨_, ws, ds, sc, hw⟩
 
+/-- LIVE: weightTail success implies weight > 0 (non-vacuous, uses h). -/
+theorem weightTail_weight_pos (tx : Bytes) (txKind baseSize anchorBytes daLen : Nat)
+    (ws : WitnessSectionResult) (c10 : Wire.Cursor) (stats : WeightStats)
+    (h : weightTail tx txKind baseSize anchorBytes daLen ws c10 = .ok stats) :
+    stats.weight > 0 := by
+  unfold weightTail at h
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact (nomatch h)
+    · injection h with h; subst h
+      show WITNESS_DISCOUNT_DIVISOR * baseSize + _ + (compactSizeLen daLen + daLen) + _ > 0
+      simp only [WITNESS_DISCOUNT_DIVISOR, VERIFY_COST_ML_DSA_87, VERIFY_COST_UNKNOWN_SUITE]
+      unfold compactSizeLen; split <;> omega
+
+/-- LIVE: finalizeTxWeight success implies weight > 0 (non-vacuous). -/
+theorem finalizeTxWeight_weight_pos (tx : Bytes) (txKind baseSize anchorBytes : Nat)
+    (ws : WitnessSectionResult) (c : Wire.Cursor) (stats : WeightStats)
+    (h : finalizeTxWeight tx txKind baseSize anchorBytes ws c = .ok stats) :
+    stats.weight > 0 := by
+  unfold finalizeTxWeight at h
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact (nomatch h)
+    · split at h
+      · split at h; · exact (nomatch h)
+        · exact weightTail_weight_pos tx txKind baseSize anchorBytes _ ws _ stats h
+      · split at h
+        · split at h; · exact (nomatch h)
+          · exact weightTail_weight_pos tx txKind baseSize anchorBytes _ ws _ stats h
+        · split at h; · exact (nomatch h)
+          · exact weightTail_weight_pos tx txKind baseSize anchorBytes _ ws _ stats h
+
+/-- LIVE: txWeightAndStats success implies weight > 0.
+    Non-vacuous: 0 is explicitly excluded from .ok results because
+    compactSizeLen ≥ 1 guarantees weight ≥ 1 in every .ok path.
+    Empty/short inputs produce .error, not .ok. -/
+theorem txWeightAndStats_weight_pos (tx : Bytes) (stats : WeightStats)
+    (h : txWeightAndStats tx = .ok stats) :
+    stats.weight > 0 := by
+  unfold txWeightAndStats at h
+  simp only [bind, Except.bind] at h
+  split at h; · exact Except.noConfusion h
+  · split at h; · exact Except.noConfusion h
+    · exact finalizeTxWeight_weight_pos tx _ _ _ _ _ stats h
+
 /-- LIVE: txWeightAndStats rejects empty input. -/
 theorem txWeightAndStats_error_empty :
     txWeightAndStats (RubinFormal.bytes #[]) = .error "TX_ERR_PARSE" := by

--- a/RubinFormal/TxWeightV2.lean
+++ b/RubinFormal/TxWeightV2.lean
@@ -196,35 +196,29 @@ def parseTxHeader (tx : Bytes) : Except String (Nat × Cursor) := do
   | some c5 => pure (txKind, c5)
 
 /-- Phase 2: Parse outputs, expiry, DA core, witness section.
-    Returns (baseSize, anchorBytes, witnessSection, cursor). -/
+    Returns (baseSize, anchorBytes, witnessSection, cursor).
+    Written without do-notation for proof tractability. -/
 def parseTxBody (txKind : Nat) (c : Cursor) :
-    Except String (Nat × Nat × WitnessSectionResult × Cursor) := do
-  let (outCount, c6, minOut) ←
-    match c.getCompactSize? with
-    | none => throw "TX_ERR_PARSE"
-    | some x => pure x
-  if !minOut then throw "TX_ERR_PARSE"
-  let (c7, anchorBytes) ←
-    match parseOutputsForAnchor c6 outCount with
-    | none => throw "TX_ERR_PARSE"
-    | some x => pure x
-  let (_, c8) ←
-    match c7.getU32le? with
-    | none => throw "TX_ERR_PARSE"
-    | some x => pure x
-  let (c9, _daCoreLen) ←
-    match DaCoreV1.parseDaCoreFieldsWithBytes txKind c8 with
-    | none => throw "TX_ERR_PARSE"
-    | some x => pure x
-  let ws ←
-    match parseWitnessSectionForWeight c9 with
-    | none => throw "TX_ERR_PARSE"
-    | some x => pure x
-  let witnessSize := ws.endOff - ws.startOff
-  if witnessSize > MAX_WITNESS_BYTES_PER_TX then
-    throw "TX_ERR_WITNESS_OVERFLOW"
-  if ws.isOverflow then throw "TX_ERR_WITNESS_OVERFLOW"
-  pure (c9.off, anchorBytes, ws, ws.cursor)
+    Except String (Nat × Nat × WitnessSectionResult × Cursor) :=
+  match c.getCompactSize? with
+  | none => .error "TX_ERR_PARSE"
+  | some (outCount, c6, minOut) =>
+    if !minOut then .error "TX_ERR_PARSE"
+    else match parseOutputsForAnchor c6 outCount with
+    | none => .error "TX_ERR_PARSE"
+    | some (c7, anchorBytes) =>
+      match c7.getU32le? with
+      | none => .error "TX_ERR_PARSE"
+      | some (_, c8) =>
+        match DaCoreV1.parseDaCoreFieldsWithBytes txKind c8 with
+        | none => .error "TX_ERR_PARSE"
+        | some (c9, _) =>
+          match parseWitnessSectionForWeight c9 with
+          | none => .error "TX_ERR_PARSE"
+          | some ws =>
+            if ws.endOff - ws.startOff > MAX_WITNESS_BYTES_PER_TX then .error "TX_ERR_WITNESS_OVERFLOW"
+            else if ws.isOverflow then .error "TX_ERR_WITNESS_OVERFLOW"
+            else .ok (c9.off, anchorBytes, ws, ws.cursor)
 
 /-- Weight computation tail: getBytes, verify EOF, compute formula. -/
 def weightTail (tx : Bytes) (txKind : Nat) (baseSize anchorBytes daLen : Nat)

--- a/RubinFormal/TxWeightV2.lean
+++ b/RubinFormal/TxWeightV2.lean
@@ -167,10 +167,9 @@ def parseWitnessSectionForWeight (c : Cursor) : Option WitnessSectionResult := d
            mlCount := mlCount, unknownSuiteCount := unknownSuiteCount,
            anySigAlgInvalid := anySigAlgInvalid, anySigNoncanonical := anySigNoncanonical }
 
-/-- **Pre-rotation scope**: sigCost = mlCount * VERIFY_COST_ML_DSA_87 + unknownCount * 64.
-    Post-rotation (Q-FORMAL-ROTATION-03, `weight_suite_aware_correct`):
-    sigCost = Σ_suite (count(suite) * registry[suite].verifyCost). -/
-def txWeightAndStats (tx : Bytes) : Except String WeightStats := do
+/-- Phase 1: Parse tx header (version, kind, locktime) + skip inputs.
+    Returns (txKind, cursor after inputs). -/
+def parseTxHeader (tx : Bytes) : Except String (Nat × Cursor) := do
   let c0 : Cursor := { bs := tx, off := 0 }
   let (_, c1) ←
     match c0.getU32le? with
@@ -187,7 +186,6 @@ def txWeightAndStats (tx : Bytes) : Except String WeightStats := do
     match c2.getU64le? with
     | none => throw "TX_ERR_PARSE"
     | some x => pure x
-
   let (inCount, c4, minIn) ←
     match c3.getCompactSize? with
     | none => throw "TX_ERR_PARSE"
@@ -195,63 +193,81 @@ def txWeightAndStats (tx : Bytes) : Except String WeightStats := do
   if !minIn then throw "TX_ERR_PARSE"
   match parseInputsSkip c4 inCount with
   | none => throw "TX_ERR_PARSE"
-  | some c5 =>
-    let (outCount, c6, minOut) ←
-      match c5.getCompactSize? with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    if !minOut then throw "TX_ERR_PARSE"
-    let (c7, anchorBytes) ←
-      match parseOutputsForAnchor c6 outCount with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    let (_, c8) ←
-      match c7.getU32le? with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    let (c9, _daCoreLen) ←
-      match DaCoreV1.parseDaCoreFieldsWithBytes txKind c8 with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    let baseSize := c9.off
+  | some c5 => pure (txKind, c5)
 
-    let ws ←
-      match parseWitnessSectionForWeight c9 with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    let witnessSize := ws.endOff - ws.startOff
-    if witnessSize > MAX_WITNESS_BYTES_PER_TX then
-      throw "TX_ERR_WITNESS_OVERFLOW"
-    if ws.isOverflow then throw "TX_ERR_WITNESS_OVERFLOW"
-    -- Weight function does NOT throw sig errors (Go parity: CalcTxWeight §9).
-    -- Sig errors are caught by ParseTx/validation, not weight calculation.
+/-- Phase 2: Parse outputs, expiry, DA core, witness section.
+    Returns (baseSize, anchorBytes, witnessSection, cursor). -/
+def parseTxBody (txKind : Nat) (c : Cursor) :
+    Except String (Nat × Nat × WitnessSectionResult × Cursor) := do
+  let (outCount, c6, minOut) ←
+    match c.getCompactSize? with
+    | none => throw "TX_ERR_PARSE"
+    | some x => pure x
+  if !minOut then throw "TX_ERR_PARSE"
+  let (c7, anchorBytes) ←
+    match parseOutputsForAnchor c6 outCount with
+    | none => throw "TX_ERR_PARSE"
+    | some x => pure x
+  let (_, c8) ←
+    match c7.getU32le? with
+    | none => throw "TX_ERR_PARSE"
+    | some x => pure x
+  let (c9, _daCoreLen) ←
+    match DaCoreV1.parseDaCoreFieldsWithBytes txKind c8 with
+    | none => throw "TX_ERR_PARSE"
+    | some x => pure x
+  let ws ←
+    match parseWitnessSectionForWeight c9 with
+    | none => throw "TX_ERR_PARSE"
+    | some x => pure x
+  let witnessSize := ws.endOff - ws.startOff
+  if witnessSize > MAX_WITNESS_BYTES_PER_TX then
+    throw "TX_ERR_WITNESS_OVERFLOW"
+  if ws.isOverflow then throw "TX_ERR_WITNESS_OVERFLOW"
+  pure (c9.off, anchorBytes, ws, ws.cursor)
 
-    let (daLen, c10, minDa) ←
-      match ws.cursor.getCompactSize? with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    if !minDa then throw "TX_ERR_PARSE"
-    if txKind == 0x00 then
-      if daLen != 0 then throw "TX_ERR_PARSE"
-    else if txKind == 0x01 then
-      if daLen > DaCoreV1.MAX_DA_MANIFEST_BYTES_PER_TX then throw "TX_ERR_PARSE"
+/-- Weight computation tail: getBytes, verify EOF, compute formula. -/
+def weightTail (tx : Bytes) (txKind : Nat) (baseSize anchorBytes daLen : Nat)
+    (ws : WitnessSectionResult) (c10 : Cursor) : Except String WeightStats :=
+  match c10.getBytes? daLen with
+  | none => .error "TX_ERR_PARSE"
+  | some (_, c11) =>
+    if c11.off != tx.size then .error "TX_ERR_PARSE"
     else
-      if daLen < 1 || daLen > DaCoreV1.CHUNK_BYTES then throw "TX_ERR_PARSE"
-    let (_, c11) ←
-      match c10.getBytes? daLen with
-      | none => throw "TX_ERR_PARSE"
-      | some x => pure x
-    if c11.off != tx.size then
-      throw "TX_ERR_PARSE"
+      let witnessSize := ws.endOff - ws.startOff
+      let daSize := compactSizeLen daLen + daLen
+      let daBytes := if txKind == 0x00 then 0 else daLen
+      let sigCost := ws.mlCount * VERIFY_COST_ML_DSA_87 +
+                     ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE
+      let weight := (WITNESS_DISCOUNT_DIVISOR * baseSize) + witnessSize + daSize + sigCost
+      .ok { weight := weight, daBytes := daBytes, anchorBytes := anchorBytes }
 
-    let daSize := compactSizeLen daLen + daLen
-    let daBytes := if txKind == 0x00 then 0 else daLen
-    let mlCost := ws.mlCount * VERIFY_COST_ML_DSA_87
-    let unknownCost := ws.unknownSuiteCount * VERIFY_COST_UNKNOWN_SUITE
-    let sigCost := mlCost + unknownCost
+/-- Phase 3: Parse DA manifest, validate, compute weight formula.
+    Written without do-notation for proof tractability (avoids __do_jp join points). -/
+def finalizeTxWeight (tx : Bytes) (txKind : Nat) (baseSize : Nat) (anchorBytes : Nat)
+    (ws : WitnessSectionResult) (c : Cursor) : Except String WeightStats :=
+  match c.getCompactSize? with
+  | none => .error "TX_ERR_PARSE"
+  | some (daLen, c10, minDa) =>
+    if !minDa then .error "TX_ERR_PARSE"
+    else if txKind == 0x00 then
+      if daLen != 0 then .error "TX_ERR_PARSE"
+      else weightTail tx txKind baseSize anchorBytes daLen ws c10
+    else if txKind == 0x01 then
+      if daLen > DaCoreV1.MAX_DA_MANIFEST_BYTES_PER_TX then .error "TX_ERR_PARSE"
+      else weightTail tx txKind baseSize anchorBytes daLen ws c10
+    else
+      if daLen < 1 || daLen > DaCoreV1.CHUNK_BYTES then .error "TX_ERR_PARSE"
+      else weightTail tx txKind baseSize anchorBytes daLen ws c10
 
-    let weight := (WITNESS_DISCOUNT_DIVISOR * baseSize) + witnessSize + daSize + sigCost
-    pure { weight := weight, daBytes := daBytes, anchorBytes := anchorBytes }
+/-- **Pre-rotation scope**: sigCost = mlCount * VERIFY_COST_ML_DSA_87 + unknownCount * 64.
+    Post-rotation (Q-FORMAL-ROTATION-03, `weight_suite_aware_correct`):
+    sigCost = Σ_suite (count(suite) * registry[suite].verifyCost).
+    Composed from parseTxHeader → parseTxBody → finalizeTxWeight for proof tractability. -/
+def txWeightAndStats (tx : Bytes) : Except String WeightStats := do
+  let (txKind, c1) ← parseTxHeader tx
+  let (baseSize, anchorBytes, ws, c2) ← parseTxBody txKind c1
+  finalizeTxWeight tx txKind baseSize anchorBytes ws c2
 
 end TxWeightV2
 

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -153,7 +153,10 @@
         "RubinFormal.finalizeTxWeight_ok",
         "RubinFormal.txWeightAndStats_ok_weight_eq",
         "RubinFormal.txWeightAndStats_error_empty",
-        "RubinFormal.txWeightAndStats_error_4bytes"
+        "RubinFormal.txWeightAndStats_error_4bytes",
+        "RubinFormal.weightTail_weight_pos",
+        "RubinFormal.finalizeTxWeight_weight_pos",
+        "RubinFormal.txWeightAndStats_weight_pos"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -180,7 +183,10 @@
         "RubinFormal.finalizeTxWeight_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_ok_weight_eq": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_error_empty": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
-        "RubinFormal.txWeightAndStats_error_4bytes": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
+        "RubinFormal.txWeightAndStats_error_4bytes": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.weightTail_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.finalizeTxWeight_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.txWeightAndStats_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
       },
       "notes": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates all error branches of parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok stats implies stats.weight = computeWeight. 27 theorems total.",
       "limitations": [],

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -148,7 +148,12 @@
         "RubinFormal.sigCost_monotone_ml",
         "RubinFormal.sigCost_monotone_unknown",
         "RubinFormal.daSize_kind0",
-        "RubinFormal.compactSizeLen_small"
+        "RubinFormal.compactSizeLen_small",
+        "RubinFormal.weightTail_ok",
+        "RubinFormal.finalizeTxWeight_ok",
+        "RubinFormal.txWeightAndStats_ok_weight_eq",
+        "RubinFormal.txWeightAndStats_error_empty",
+        "RubinFormal.txWeightAndStats_error_short"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -170,13 +175,16 @@
         "RubinFormal.sigCost_monotone_ml": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.sigCost_monotone_unknown": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.daSize_kind0": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
-        "RubinFormal.compactSizeLen_small": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
+        "RubinFormal.compactSizeLen_small": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.weightTail_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.finalizeTxWeight_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.txWeightAndStats_ok_weight_eq": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.txWeightAndStats_error_empty": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.txWeightAndStats_error_short": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
       },
-      "notes": "Weight accounting behaviourally closed: (1) all 5 normative constants pinned, (2) live 4-component formula decomposed with abstract model bridge, (3) sigCost = mlCount*8 + unknownCount*64 with monotonicity, (4) DA component kind=0 proved (daLen=0 → daSize=1 → daBytes=0), (5) all 4 components independently monotone, (6) conformance replay on real byte sequences, (7) suite-aware post-rotation model via registry lookups. Full monadic parse-to-weight threading deliberately not attempted — behavioral decomposition + CV replay provides equivalent assurance.",
-      "limitations": [
-        "Full end-to-end monadic parse-to-weight theorem (threading through Option/Except chain) deliberately not attempted — behavioral decomposition + CV replay combination provides equivalent assurance without brittle coupling to internal parser state."
-      ],
-      "evidence_level": "machine_checked_behavioral"
+      "notes": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates all error branches of parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok stats implies stats.weight = computeWeight. 27 theorems total.",
+      "limitations": [],
+      "evidence_level": "machine_checked_universal"
     },
     {
       "section_key": "witness_commitment",

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -153,7 +153,7 @@
         "RubinFormal.finalizeTxWeight_ok",
         "RubinFormal.txWeightAndStats_ok_weight_eq",
         "RubinFormal.txWeightAndStats_error_empty",
-        "RubinFormal.txWeightAndStats_error_short"
+        "RubinFormal.txWeightAndStats_error_4bytes"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -180,7 +180,7 @@
         "RubinFormal.finalizeTxWeight_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_ok_weight_eq": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_error_empty": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
-        "RubinFormal.txWeightAndStats_error_short": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
+        "RubinFormal.txWeightAndStats_error_4bytes": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
       },
       "notes": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates all error branches of parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok stats implies stats.weight = computeWeight. 27 theorems total.",
       "limitations": [],

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -152,6 +152,7 @@
         "RubinFormal.weightTail_ok",
         "RubinFormal.finalizeTxWeight_ok",
         "RubinFormal.txWeightAndStats_ok_weight_eq",
+        "RubinFormal.txWeightAndStats_ok_weight_eq_constrained",
         "RubinFormal.txWeightAndStats_error_empty",
         "RubinFormal.txWeightAndStats_error_4bytes",
         "RubinFormal.weightTail_weight_pos",
@@ -182,13 +183,14 @@
         "RubinFormal.weightTail_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.finalizeTxWeight_ok": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_ok_weight_eq": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
+        "RubinFormal.txWeightAndStats_ok_weight_eq_constrained": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_error_empty": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_error_4bytes": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.weightTail_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.finalizeTxWeight_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
         "RubinFormal.txWeightAndStats_weight_pos": "rubin-formal/RubinFormal/TxWeightBehavioral.lean"
       },
-      "notes": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates all error branches of parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok stats implies stats.weight = computeWeight. 27 theorems total.",
+      "notes": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq_constrained records the successful parseTxHeader + parseTxBody + finalizeTxWeight chain and proves the resulting .ok stats weight matches computeWeight on parse-derived witnesses. 29 theorems total.",
       "limitations": [],
       "evidence_level": "machine_checked_universal"
     },

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -209,12 +209,11 @@
       "model_theorem": "RubinFormal.weight_cv_replay_pass",
       "lean_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "theorem_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
-      "evidence_level": "machine_checked_behavioral",
+      "evidence_level": "machine_checked_universal",
       "spec_section": "§9",
       "go_function": "CalcTxWeight",
-      "contract_scope": "Behavioral decomposition of the live weight formula (base/witness/DA/signature) with abstract model bridge + conformance replay. Constants pinned, all 4 components independently monotone, DA-component kind=0 proved, sigCost decomposition proved.",
+      "contract_scope": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok implies weight = computeWeight. Refactored into sub-functions for kernel tractability.",
       "limitations": [
-        "Full end-to-end monadic parse-to-weight theorem (threading through Option/Except chain of txWeightAndStats) is deliberately not attempted — behavioral decomposition + CV replay provides equivalent assurance.",
         "Post-rotation suite-aware cost model proved separately in WeightSuiteAware.lean."
       ],
       "supporting_theorems": [

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -206,7 +206,7 @@
     {
       "op": "weight_accounting",
       "gate": "CV-WEIGHT",
-      "model_theorem": "RubinFormal.txWeightAndStats_weight_pos",
+      "model_theorem": "RubinFormal.txWeightAndStats_ok_weight_eq",
       "lean_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "theorem_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "evidence_level": "machine_checked_universal",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -206,7 +206,7 @@
     {
       "op": "weight_accounting",
       "gate": "CV-WEIGHT",
-      "model_theorem": "RubinFormal.weight_cv_replay_pass",
+      "model_theorem": "RubinFormal.txWeightAndStats_ok_weight_eq",
       "lean_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "theorem_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "evidence_level": "machine_checked_universal",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -206,7 +206,7 @@
     {
       "op": "weight_accounting",
       "gate": "CV-WEIGHT",
-      "model_theorem": "RubinFormal.txWeightAndStats_ok_weight_eq",
+      "model_theorem": "RubinFormal.txWeightAndStats_weight_pos",
       "lean_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "theorem_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "evidence_level": "machine_checked_universal",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -206,18 +206,20 @@
     {
       "op": "weight_accounting",
       "gate": "CV-WEIGHT",
-      "model_theorem": "RubinFormal.txWeightAndStats_ok_weight_eq",
+      "model_theorem": "RubinFormal.txWeightAndStats_ok_weight_eq_constrained",
       "lean_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "theorem_file": "rubin-formal/RubinFormal/TxWeightBehavioral.lean",
       "evidence_level": "machine_checked_universal",
       "spec_section": "§9",
       "go_function": "CalcTxWeight",
-      "contract_scope": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq navigates parseTxHeader + parseTxBody + finalizeTxWeight, proving .ok implies weight = computeWeight. Refactored into sub-functions for kernel tractability.",
+      "contract_scope": "Universal closure of S9 weight formula. Full Except-chain proof: txWeightAndStats_ok_weight_eq_constrained records the successful parseTxHeader + parseTxBody + finalizeTxWeight chain and proves .ok implies the returned weight matches computeWeight on parse-derived witnesses.",
       "limitations": [
         "Post-rotation suite-aware cost model proved separately in WeightSuiteAware.lean."
       ],
       "supporting_theorems": [
         "RubinFormal.Conformance.cv_weight_vectors_pass",
+        "RubinFormal.txWeightAndStats_ok_weight_eq",
+        "RubinFormal.txWeightAndStats_weight_pos",
         "RubinFormal.weight_formula_bridges_abstract",
         "RubinFormal.weight_discount_divisor_value",
         "RubinFormal.weight_verify_cost_ml_dsa_value",
@@ -234,7 +236,7 @@
         "RubinFormal.WeightSuiteAware.weight_suite_aware_correct_create",
         "RubinFormal.weight_accounting_proved"
       ],
-      "notes": "Behavioral closure of §9 weight formula. The live txWeightAndStats function is validated against CV vectors (native_decide), and the weight formula is decomposed into pure functions with full monotonicity and abstract model equivalence. Suite-aware cost model (post-rotation) covered by WeightSuiteAware.lean."
+      "notes": "Universal closure of §9 weight formula. The live txWeightAndStats path now has a parse-constrained full-chain theorem plus a non-vacuous positivity guard; CV-WEIGHT remains the executable evidence lane, and WeightSuiteAware.lean covers the separate post-rotation suite-cost model."
     },
     {
       "op": "native_suite_rotation",


### PR DESCRIPTION
## Summary

Supersedes #377 with a stricter universal bridge for `weight_accounting`.

This keeps the `machine_checked_universal` target, but removes the main overclaim smell by anchoring the bridge on a parse-constrained LIVE theorem instead of the weaker existential-only decomposition theorem.

### What changed

- Added `txWeightAndStats_ok_weight_eq_constrained`
  - records the successful `parseTxHeader -> parseTxBody -> finalizeTxWeight` chain
  - proves the returned `.ok stats` weight matches `computeWeight` on parse-derived witnesses
- kept `txWeightAndStats_ok_weight_eq` as supporting decomposition theorem
- kept `txWeightAndStats_weight_pos` and now include it in machine-readable supporting evidence
- narrowed the non-vacuous docstring claim from vague `empty/short` wording to the exact proved surface
- aligned `proof_coverage.json` and `refinement_bridge.json` to the actual theorem surface

### Why this supersedes #377

`#377` was green and mergeable, but its universal claim still leaned on an existential theorem whose statement did not itself bind witnesses back to parse outputs. This PR makes the machine-readable universal claim match the real proof contract.

### Validation

- `lake build` PASS
- `python3 tools/check_formal_registry_truth.py` PASS
- pre-commit hook PASS
- sanctioned pre-push validation PASS

No consensus semantics changed.
