### PR TITLE
formal: upgrade spend_gate_bridge → machine_checked_universal

### DIFF
--- a/RubinFormal/FormalGap03.lean
+++ b/RubinFormal/FormalGap03.lean
@@ -103,9 +103,25 @@ theorem validateP2PKSpendPreSig_binds_pubkey
     entry.covenantData.size = CovenantGenesisV1.MAX_P2PK_COVENANT_DATA ∧
     (entry.covenantData.get! 0).toNat = w.suiteId ∧
     p2pkPubkeyKeyIdBound entry w := by
+  have hSuiteCanonical :
+      UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 = RubinFormal.SUITE_ID_ML_DSA_87 := by
+    native_decide
   by_cases hSuite : (w.suiteId != UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87) = true
-  · have hErr : validateP2PKSpendPreSig entry w blockHeight = .error "TX_ERR_SIG_ALG_INVALID" := by
-      simp [validateP2PKSpendPreSig, hSuite, Except.bind]
+  · have hSuiteNe : w.suiteId ≠ UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 := by
+      intro hEq
+      simp [hEq] at hSuite
+    have hSuiteNeCanonical : w.suiteId ≠ RubinFormal.SUITE_ID_ML_DSA_87 := by
+      intro hEq
+      apply hSuiteNe
+      rw [hSuiteCanonical]
+      exact hEq
+    have hGateFalse :
+        NativeSpendCreateGate.liveSpendGateAllows none blockHeight w.suiteId = false := by
+      unfold NativeSpendCreateGate.liveSpendGateAllows
+      simp [hSuiteNeCanonical]
+    have hErr : validateP2PKSpendPreSig entry w blockHeight = .error "TX_ERR_SIG_ALG_INVALID" := by
+      unfold validateP2PKSpendPreSig
+      simp [hGateFalse]
       rfl
     rw [hErr] at hOk
     cases hOk
@@ -117,9 +133,18 @@ theorem validateP2PKSpendPreSig_binds_pubkey
     have hSuiteEq : w.suiteId = UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 := by
       by_contra hNeEq
       exact hSuite (by simp [hNeEq])
+    have hSuiteEqCanonical : w.suiteId = RubinFormal.SUITE_ID_ML_DSA_87 := by
+      calc
+        w.suiteId = UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 := hSuiteEq
+        _ = RubinFormal.SUITE_ID_ML_DSA_87 := hSuiteCanonical
+    have hGateTrue :
+        NativeSpendCreateGate.liveSpendGateAllows none blockHeight w.suiteId = true := by
+      unfold NativeSpendCreateGate.liveSpendGateAllows
+      simp [hSuiteEqCanonical]
     by_cases hSize : (entry.covenantData.size != CovenantGenesisV1.MAX_P2PK_COVENANT_DATA) = true
     · have hErr : validateP2PKSpendPreSig entry w blockHeight = .error "TX_ERR_COVENANT_TYPE_INVALID" := by
-        simp [validateP2PKSpendPreSig, hSuiteFalse, hSize, Except.bind]
+        unfold validateP2PKSpendPreSig
+        simp [hGateTrue, hSize]
         rfl
       rw [hErr] at hOk
       cases hOk
@@ -133,7 +158,8 @@ theorem validateP2PKSpendPreSig_binds_pubkey
         exact hSize (by simp [hNeEq])
       by_cases hTag : ((entry.covenantData.get! 0).toNat != w.suiteId) = true
       · have hErr : validateP2PKSpendPreSig entry w blockHeight = .error "TX_ERR_COVENANT_TYPE_INVALID" := by
-          simp [validateP2PKSpendPreSig, hSuiteFalse, hSizeFalse, hTag, Except.bind]
+          unfold validateP2PKSpendPreSig
+          simp [hGateTrue, hSizeFalse, hTag]
           rfl
         rw [hErr] at hOk
         cases hOk
@@ -148,7 +174,8 @@ theorem validateP2PKSpendPreSig_binds_pubkey
         cases hHash : (SHA3.sha3_256 w.pubkey != entry.covenantData.extract 1 33) with
         | true =>
           have hErr : validateP2PKSpendPreSig entry w blockHeight = .error "TX_ERR_SIG_INVALID" := by
-            simp [validateP2PKSpendPreSig, hSuiteFalse, hSizeFalse, hTagFalse, hHash, Except.bind]
+            unfold validateP2PKSpendPreSig
+            simp [hGateTrue, hSizeFalse, hTagFalse, hHash]
             rfl
           rw [hErr] at hOk
           cases hOk

--- a/RubinFormal/NativeSpendCreateGate.lean
+++ b/RubinFormal/NativeSpendCreateGate.lean
@@ -46,6 +46,15 @@ def nativeSpendGate
   if suiteId ∈ NativeSpendSuites h d then GateResult.accept
   else GateResult.reject_sig_alg_invalid
 
+/-- Descriptor-aware live spend gate predicate.
+    `none` keeps the pre-rotation singleton behavior `{ML_DSA_87}`.
+    `some d` lifts the post-rotation model gate onto the live spend path. -/
+def liveSpendGateAllows
+    (rotDesc? : Option RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat) : Bool :=
+  match rotDesc? with
+  | none => decide (suiteId = RubinFormal.SUITE_ID_ML_DSA_87)
+  | some d => decide (nativeSpendGate d h suiteId = GateResult.accept)
+
 /-- The native P2PK create gate: accepts iff suite_id ∈ NATIVE_CREATE_SUITES(h).
     P2PK is the only native covenant that commits suite_id at creation time. -/
 def nativeP2PKCreateGate
@@ -85,6 +94,52 @@ theorem fi_rot_04_spend_gate_iff
   · intro hmem
     unfold nativeSpendGate
     simp [hmem]
+
+/-- Pre-rotation fallback branch of the live spend gate helper. -/
+theorem liveSpendGateAllows_none_iff
+    (h : Nat) (suiteId : Nat) :
+    liveSpendGateAllows none h suiteId = true ↔
+    suiteId = RubinFormal.SUITE_ID_ML_DSA_87 := by
+  constructor
+  · intro hAllow
+    simpa [liveSpendGateAllows] using hAllow
+  · intro hEq
+    simp [liveSpendGateAllows, hEq]
+
+/-- Post-rotation branch of the live spend gate helper is equivalent to the
+    abstract spend gate acceptance criterion. -/
+theorem liveSpendGateAllows_some_iff
+    (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat) :
+    liveSpendGateAllows (some d) h suiteId = true ↔
+    suiteId ∈ NativeSpendSuites h d := by
+  constructor
+  · intro hAllow
+    have hGate : nativeSpendGate d h suiteId = GateResult.accept := by
+      simpa [liveSpendGateAllows] using hAllow
+    exact (fi_rot_04_spend_gate_iff d h suiteId).mp hGate
+  · intro hMem
+    have hGate : nativeSpendGate d h suiteId = GateResult.accept :=
+      (fi_rot_04_spend_gate_iff d h suiteId).mpr hMem
+    simp [liveSpendGateAllows, hGate]
+
+/-- Boolean false form of the post-rotation live spend gate helper. -/
+theorem liveSpendGateAllows_some_false_iff
+    (d : RotationDeploymentDescriptor) (h : Nat) (suiteId : Nat) :
+    liveSpendGateAllows (some d) h suiteId = false ↔
+    suiteId ∉ NativeSpendSuites h d := by
+  constructor
+  · intro hFalse
+    intro hMem
+    have hTrue : liveSpendGateAllows (some d) h suiteId = true :=
+      (liveSpendGateAllows_some_iff d h suiteId).mpr hMem
+    rw [hFalse] at hTrue
+    cases hTrue
+  · intro hNotMem
+    cases hAllow : liveSpendGateAllows (some d) h suiteId with
+    | false => rfl
+    | true =>
+        exfalso
+        exact hNotMem ((liveSpendGateAllows_some_iff d h suiteId).mp hAllow)
 
 /-- FI-ROT-04: spend gate is determined solely by (d, h, suiteId).
     No covenant-type-specific logic: the gate function signature takes

--- a/RubinFormal/RotationPrelude.lean
+++ b/RubinFormal/RotationPrelude.lean
@@ -98,8 +98,9 @@ def preRotationActiveSuites (_h : Nat) : List Nat := [0x01]
     **Action for ROT-04**: generalise to `suiteId ∉ NATIVE_CREATE_SUITES(h) → reject`.
 
   #### UtxoApplyGenesisV1.lean
-  - `validateP2PKSpendPreSig`: `suite != SUITE_ID_ML_DSA_87 → reject`.
-    **Action for ROT-04**: generalise to `suite ∉ NATIVE_SPEND_SUITES(h) → reject`.
+  - `validateP2PKSpendPreSig`: descriptor-aware live spend gate.
+    `rotDesc? = none` keeps pre-rotation `{ML_DSA_87}`;
+    `rotDesc? = some d` enforces `suite ∈ NATIVE_SPEND_SUITES(h,d)`.
   - `validateWitnessItemLengths`: ML-DSA-87 branch with hardcoded bounds.
     **Action for ROT-02/ROT-03**: lookup bounds from registry.
   - `validateThresholdSigSpendNoCrypto`: ML-DSA-87 branch.
@@ -108,14 +109,16 @@ def preRotationActiveSuites (_h : Nat) : List Nat := [0x01]
     **Action**: update samples if registry model changes output format.
 
   #### UtxoBasicV1.lean
-  - `scanSingleInputStep`: `suite != SUITE_ID_ML_DSA_87 → reject` in P2PK path.
-    **Action for ROT-04**: generalise to `suite ∉ NATIVE_SPEND_SUITES(h)`.
+  - `scanSingleInputStep`: descriptor-aware P2PK input gate.
+    `rotDesc? = none` keeps pre-rotation `{ML_DSA_87}`;
+    `rotDesc? = some d` enforces `suite ∈ NATIVE_SPEND_SUITES(h,d)`.
 
   #### FormalGap03.lean
   - `sem001MLDSABoundedLengthStatement`: hypothesis `w.suiteId = SUITE_ID_ML_DSA_87`.
     **Already scoped** — valid pre-rotation; post-rotation needs per-suite variant.
   - `validateP2PKSpendPreSig_binds_pubkey`: conclusion includes `w.suiteId = SUITE_ID_ML_DSA_87`.
-    **Already scoped** — follows from `validateP2PKSpendPreSig` accepting only ML-DSA-87.
+    **Already scoped** — follows from `validateP2PKSpendPreSig` on the default `none`
+    pre-rotation branch accepting only ML-DSA-87.
   - `sem002_mldsa_binding_proved`: composition of above two.
     **Already scoped** — inherits scope from premises.
 -/

--- a/RubinFormal/SpendGateLiveBridge.lean
+++ b/RubinFormal/SpendGateLiveBridge.lean
@@ -1,19 +1,21 @@
 /-
   RubinFormal/SpendGateLiveBridge.lean — Spend/Create Gate Bridge
 
-  Evidence level for this file remains behavioral on the counted LIVE+BRIDGE
-  row. `spend_create_gate_ok_constrained` is a helper theorem for the
-  spend/create gate model surface: ∀ well-formed descriptor, ∀ height,
+  Counted LIVE+BRIDGE row for this file is the descriptor-aware spend-side
+  live bridge. `spend_create_gate_ok_constrained` remains a helper theorem
+  for the spend/create gate model surface: ∀ well-formed descriptor, ∀ height,
   spend and create gates accept ↔ suite membership, and accepted suites
   are never sentinel.
 
-  Pre-rotation live bridge (validateP2PKSpendPreSig) covers the
-  pre-rotation hardcoded `suite != ML_DSA_87` check.
-  Post-rotation live function bridge not yet formalized (G7 residual).
+  The counted closure is now the real live P2PK spend path:
+  - `validateP2PKSpendPreSig` on the descriptor-aware branch
+  - `scanSingleInputStep` on the descriptor-aware P2PK branch
+
+  Pre-rotation corollaries remain available through the `none` fallback.
 
   Spec: CANONICAL §5.4 (witness suite gating), §4.1.2 (rotation phases).
   Depends: NativeSpendCreateGate.lean (FI-ROT-04/05).
-  Closes #285.
+  Closes #285, #369.
 -/
 
 import RubinFormal.NativeSpendCreateGate
@@ -166,6 +168,35 @@ private theorem utxo_suite_eq_canonical :
     UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 = RubinFormal.SUITE_ID_ML_DSA_87 := by
   native_decide
 
+private theorem uint8_beq_eq_decide (x y : UInt8) :
+    BEq.beq x y = decide (x = y) := by
+  cases x with
+  | mk xv =>
+    cases y with
+    | mk yv =>
+      simp [BEq.beq]
+
+private theorem bytes_beq_refl (a : Bytes) : (a == a) = true := by
+  cases a with
+  | mk ad =>
+      show Array.isEqv ad ad BEq.beq = true
+      have h :
+          (fun (x y : UInt8) => @BEq.beq UInt8 _ x y) =
+          (fun x y => decide (x = y)) := by
+        funext x y
+        exact uint8_beq_eq_decide x y
+      have hrw :
+          Array.isEqv ad ad BEq.beq =
+          Array.isEqv ad ad (fun x y => decide (x = y)) := by
+        congr 1
+      rw [hrw]
+      exact Array.isEqv_self ad
+
+private theorem bytes_bne_self_false (a : Bytes) : (a != a) = false := by
+  show (!(a == a)) = false
+  rw [bytes_beq_refl]
+  rfl
+
 /-- Live suite check does not fire when model gate accepts.
     validateP2PKSpendPreSig line 44: `if suite != SUITE_ID_ML_DSA_87 then throw`.
     When model gate accepts (pre-rotation), suiteId = ML_DSA_87,
@@ -246,6 +277,134 @@ theorem spend_create_gate_ok_constrained
    fun sid => fi_rot_05_create_gate_iff d h sid,
    fun sid hacc => fi_rot_04_accepted_not_sentinel reg d h sid hwf hacc,
    fun sid hacc => fi_rot_05_accepted_not_sentinel reg d h sid hwf hacc⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- §  Post-rotation live bridge on the real spend path
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- If a suite is inactive at height `h`, the live P2PK spend validator rejects
+    immediately with `TX_ERR_SIG_ALG_INVALID` on the descriptor-aware path. -/
+theorem validateP2PKSpendPreSig_rejects_inactive_suite
+    (d : RotationDeploymentDescriptor)
+    (entry : UtxoBasicV1.UtxoEntry)
+    (w : UtxoBasicV1.WitnessItem)
+    (h : Nat)
+    (hNotMem : w.suiteId ∉ NativeSpendSuites h d) :
+    UtxoApplyGenesisV1.validateP2PKSpendPreSig entry w h (some d) =
+      .error "TX_ERR_SIG_ALG_INVALID" := by
+  have hGate :
+      NativeSpendCreateGate.liveSpendGateAllows (some d) h w.suiteId = false :=
+    (NativeSpendCreateGate.liveSpendGateAllows_some_false_iff d h w.suiteId).mpr hNotMem
+  unfold UtxoApplyGenesisV1.validateP2PKSpendPreSig
+  simp [hGate]
+  rfl
+
+/-- Descriptor-aware live P2PK spend bridge: once the same structural
+    preconditions used by the live validator are satisfied, `.ok ()`
+    is equivalent to membership in `NativeSpendSuites h d`. -/
+theorem validateP2PKSpendPreSig_ok_constrained
+    (d : RotationDeploymentDescriptor)
+    (entry : UtxoBasicV1.UtxoEntry)
+    (w : UtxoBasicV1.WitnessItem)
+    (h : Nat)
+    (hSize : entry.covenantData.size = CovenantGenesisV1.MAX_P2PK_COVENANT_DATA)
+    (hTag : (entry.covenantData.get! 0).toNat = w.suiteId)
+    (hHash : SHA3.sha3_256 w.pubkey = entry.covenantData.extract 1 33) :
+    UtxoApplyGenesisV1.validateP2PKSpendPreSig entry w h (some d) = .ok () ↔
+    w.suiteId ∈ NativeSpendSuites h d := by
+  constructor
+  · intro hOk
+    by_contra hNotMem
+    have hErr :=
+      validateP2PKSpendPreSig_rejects_inactive_suite d entry w h hNotMem
+    rw [hErr] at hOk
+    cases hOk
+  · intro hMem
+    have hGate :
+        NativeSpendCreateGate.liveSpendGateAllows (some d) h w.suiteId = true :=
+      (NativeSpendCreateGate.liveSpendGateAllows_some_iff d h w.suiteId).mpr hMem
+    have hHashFalse : (SHA3.sha3_256 w.pubkey != entry.covenantData.extract 1 33) = false := by
+      rw [hHash]
+      exact bytes_bne_self_false _
+    unfold UtxoApplyGenesisV1.validateP2PKSpendPreSig
+    simp [hGate, hSize, hTag, hHashFalse]
+    rfl
+
+/-- Deterministic successful result for the P2PK branch of `scanSingleInputStep`
+    once all earlier live guards have passed. -/
+private def p2pkScanResult
+    (input : UtxoBasicV1.TxIn)
+    (e : UtxoBasicV1.UtxoEntry)
+    (acc : UtxoBasicV1.InputScanState) : UtxoBasicV1.InputScanState :=
+  { acc with
+      sumIn := acc.sumIn + e.value
+      inputLockIds := acc.inputLockIds.concat (UtxoBasicV1.outputDescriptorLockId e)
+      inputCovTypes := acc.inputCovTypes.concat e.covenantType
+      requiredWitnessSlots := acc.requiredWitnessSlots + 1
+      consumedOutpoints := acc.consumedOutpoints.concat (UtxoBasicV1.txInOutpoint input)
+  }
+
+/-- On the real input-scan path, an inactive P2PK suite is rejected with
+    `TX_ERR_COVENANT_TYPE_INVALID` once the earlier non-suite guards have passed. -/
+theorem scanSingleInputStep_rejects_inactive_p2pk_suite
+    (d : RotationDeploymentDescriptor)
+    (input : UtxoBasicV1.TxIn)
+    (utxoMap : Std.RBMap UtxoBasicV1.Outpoint UtxoBasicV1.UtxoEntry UtxoBasicV1.cmpOutpoint)
+    (height : Nat)
+    (acc : UtxoBasicV1.InputScanState)
+    (e : UtxoBasicV1.UtxoEntry)
+    (hNoDup : acc.consumedOutpoints.contains (UtxoBasicV1.txInOutpoint input) = false)
+    (hFind : utxoMap.find? (UtxoBasicV1.txInOutpoint input) = some e)
+    (hMaturity : UtxoBasicV1.validateCoinbaseMaturity e height = .ok ())
+    (hP2PK : e.covenantType = UtxoBasicV1.COV_TYPE_P2PK)
+    (hSize : e.covenantData.size = CovenantGenesisV1.MAX_P2PK_COVENANT_DATA)
+    (hNotMem : (e.covenantData.get! 0).toNat ∉ NativeSpendSuites height d) :
+    UtxoBasicV1.scanSingleInputStep input utxoMap height acc (some d) =
+      .error "TX_ERR_COVENANT_TYPE_INVALID" := by
+  have hGate :
+      NativeSpendCreateGate.liveSpendGateAllows (some d) height (e.covenantData.get! 0).toNat = false :=
+    (NativeSpendCreateGate.liveSpendGateAllows_some_false_iff d height (e.covenantData.get! 0).toNat).mpr hNotMem
+  unfold UtxoBasicV1.scanSingleInputStep
+  simp [hNoDup, hFind, hMaturity, hP2PK, hSize, hGate,
+    UtxoBasicV1.COV_TYPE_P2PK, UtxoBasicV1.COV_TYPE_ANCHOR, UtxoBasicV1.COV_TYPE_DA_COMMIT,
+    UtxoBasicV1.COV_TYPE_VAULT]
+  rfl
+
+/-- Descriptor-aware live input-scan bridge for the P2PK branch: under the
+    same preceding guards as the live scanner, the step succeeds iff the
+    committed suite is active in `NativeSpendSuites h d`. -/
+theorem scanSingleInputStep_ok_constrained
+    (d : RotationDeploymentDescriptor)
+    (input : UtxoBasicV1.TxIn)
+    (utxoMap : Std.RBMap UtxoBasicV1.Outpoint UtxoBasicV1.UtxoEntry UtxoBasicV1.cmpOutpoint)
+    (height : Nat)
+    (acc : UtxoBasicV1.InputScanState)
+    (e : UtxoBasicV1.UtxoEntry)
+    (hNoDup : acc.consumedOutpoints.contains (UtxoBasicV1.txInOutpoint input) = false)
+    (hFind : utxoMap.find? (UtxoBasicV1.txInOutpoint input) = some e)
+    (hMaturity : UtxoBasicV1.validateCoinbaseMaturity e height = .ok ())
+    (hP2PK : e.covenantType = UtxoBasicV1.COV_TYPE_P2PK)
+    (hSize : e.covenantData.size = CovenantGenesisV1.MAX_P2PK_COVENANT_DATA) :
+    UtxoBasicV1.scanSingleInputStep input utxoMap height acc (some d) =
+      .ok (p2pkScanResult input e acc) ↔
+    (e.covenantData.get! 0).toNat ∈ NativeSpendSuites height d := by
+  constructor
+  · intro hOk
+    by_contra hNotMem
+    have hErr :=
+      scanSingleInputStep_rejects_inactive_p2pk_suite
+        d input utxoMap height acc e hNoDup hFind hMaturity hP2PK hSize hNotMem
+    rw [hErr] at hOk
+    cases hOk
+  · intro hMem
+    have hGate :
+        NativeSpendCreateGate.liveSpendGateAllows (some d) height (e.covenantData.get! 0).toNat = true :=
+      (NativeSpendCreateGate.liveSpendGateAllows_some_iff d height (e.covenantData.get! 0).toNat).mpr hMem
+    unfold UtxoBasicV1.scanSingleInputStep
+    simp [p2pkScanResult, hNoDup, hFind, hMaturity, hP2PK, hSize, hGate,
+      UtxoBasicV1.COV_TYPE_P2PK, UtxoBasicV1.COV_TYPE_ANCHOR, UtxoBasicV1.COV_TYPE_DA_COMMIT,
+      UtxoBasicV1.COV_TYPE_VAULT]
+    rfl
 
 end SpendGateLiveBridge
 

--- a/RubinFormal/UtxoApplyGenesisV1.lean
+++ b/RubinFormal/UtxoApplyGenesisV1.lean
@@ -3,6 +3,7 @@ import RubinFormal.SHA3_256
 import RubinFormal.OutputDescriptorV2
 import RubinFormal.UtxoBasicV1
 import RubinFormal.CovenantGenesisV1
+import RubinFormal.NativeSpendCreateGate
 
 namespace RubinFormal
 
@@ -44,11 +45,17 @@ def lockIdOfEntry (e : UtxoEntry) : Bytes :=
 def parseU16le (b0 b1 : UInt8) : Nat :=
   Wire.u16le? b0 b1
 
-/-- **Pre-rotation scope**: rejects any `suite ≠ ML_DSA_87`.
-    Post-rotation (Q-FORMAL-ROTATION-04): `suite ∉ NATIVE_SPEND_SUITES(h) → reject`. -/
-def validateP2PKSpendPreSig (entry : UtxoEntry) (w : WitnessItem) (_blockHeight : Nat) : Except String Unit := do
+/-- Descriptor-aware live P2PK spend gate.
+    `none` keeps the pre-rotation singleton `{ML_DSA_87}`.
+    `some d` enforces `suite ∈ NATIVE_SPEND_SUITES(h,d)`. -/
+def validateP2PKSpendPreSig
+    (entry : UtxoEntry)
+    (w : WitnessItem)
+    (blockHeight : Nat)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String Unit := do
   let suite := w.suiteId
-  if suite != SUITE_ID_ML_DSA_87 then
+  if !NativeSpendCreateGate.liveSpendGateAllows rotDesc? blockHeight suite then
     throw "TX_ERR_SIG_ALG_INVALID"
   if entry.covenantData.size != CovenantGenesisV1.MAX_P2PK_COVENANT_DATA then
     throw "TX_ERR_COVENANT_TYPE_INVALID"
@@ -376,7 +383,9 @@ def applyNonCoinbaseTxBasicNoCrypto
     (height : Nat)
     (blockTimestamp : Nat)
     (blockMtp : Nat)
-    (chainId : Bytes) : Except String (Nat × Nat) := do
+    (chainId : Bytes)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String (Nat × Nat) := do
   let _ := chainId
   let tx ← UtxoBasicV1.parseTx txBytes
 
@@ -416,7 +425,7 @@ def applyNonCoinbaseTxBasicNoCrypto
     | .p2pk nextWitnessCursor =>
       let w := tx.witness.get! witnessCursor
       -- pre-signature checks only
-      validateP2PKSpendPreSig e w height
+      validateP2PKSpendPreSig e w height rotDesc?
       witnessCursor := nextWitnessCursor
     | .multisig m nextWitnessCursor =>
       let assigned := (tx.witness.drop witnessCursor).take (nextWitnessCursor - witnessCursor)

--- a/RubinFormal/UtxoBasicV1.lean
+++ b/RubinFormal/UtxoBasicV1.lean
@@ -5,6 +5,7 @@ import RubinFormal.OutputDescriptorV2
 import RubinFormal.SighashV1
 import RubinFormal.TxParseV2
 import RubinFormal.CovenantGenesisV1
+import RubinFormal.NativeSpendCreateGate
 
 namespace RubinFormal
 
@@ -516,7 +517,9 @@ def scanSingleInputStep
     (input : TxIn)
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (height : Nat)
-    (acc : InputScanState) : Except String InputScanState := do
+    (acc : InputScanState)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String InputScanState := do
   let op := txInOutpoint input
   if acc.consumedOutpoints.contains op then
     throw "TX_ERR_PARSE"
@@ -533,10 +536,10 @@ def scanSingleInputStep
   if e.covenantType == COV_TYPE_P2PK then
     if e.covenantData.size != MAX_P2PK_COVENANT_DATA then
       throw "TX_ERR_COVENANT_TYPE_INVALID"
-    -- Pre-rotation scope: only ML-DSA-87 allowed for P2PK spend.
-    -- Post-rotation (Q-FORMAL-ROTATION-04): suite ∉ NATIVE_SPEND_SUITES(h) → reject.
+    -- Descriptor-aware spend gate: none => pre-rotation {ML_DSA_87};
+    -- some d => suite ∉ NATIVE_SPEND_SUITES(h,d) → reject.
     let suite := (e.covenantData.get! 0).toNat
-    if suite != SUITE_ID_ML_DSA_87 then
+    if !NativeSpendCreateGate.liveSpendGateAllows rotDesc? height suite then
       throw "TX_ERR_COVENANT_TYPE_INVALID"
 
   let lockId := outputDescriptorLockId e
@@ -571,18 +574,22 @@ def scanInputsGo
     (inputs : List TxIn)
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (height : Nat)
-    (acc : InputScanState) : Except String InputScanState := do
+    (acc : InputScanState)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String InputScanState := do
   match inputs with
   | [] => pure acc
   | i :: rest =>
-      let nextAcc ← scanSingleInputStep i utxoMap height acc
-      scanInputsGo rest utxoMap height nextAcc
+      let nextAcc ← scanSingleInputStep i utxoMap height acc rotDesc?
+      scanInputsGo rest utxoMap height nextAcc rotDesc?
 
 def scanInputs
     (inputs : List TxIn)
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
-    (height : Nat) : Except String InputScanState :=
-  scanInputsGo inputs utxoMap height InputScanState.empty
+    (height : Nat)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String InputScanState :=
+  scanInputsGo inputs utxoMap height InputScanState.empty rotDesc?
 
 def eraseInputs
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
@@ -669,14 +676,16 @@ def prepareNonCoinbaseTxCore
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (height : Nat)
     (blockTimestamp : Nat)
-    (chainId : Bytes) : Except String PreparedNonCoinbaseTxCore := do
+    (chainId : Bytes)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String PreparedNonCoinbaseTxCore := do
   let _ := blockTimestamp
   let _ := chainId
   let tx ← parseTx txBytes
 
   validateBasicTxEnvelope tx
   validateStructuralInputs tx.inputs
-  let inputState ← scanInputs tx.inputs utxoMap height
+  let inputState ← scanInputs tx.inputs utxoMap height rotDesc?
 
   validateBasicWitnessLayout tx inputState
   validateBasicVaultSpend tx inputState
@@ -688,8 +697,10 @@ def prepareNonCoinbaseTxBasic
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (height : Nat)
     (blockTimestamp : Nat)
-    (chainId : Bytes) : Except String PreparedNonCoinbaseTx := do
-  let core ← prepareNonCoinbaseTxCore txBytes utxoMap height blockTimestamp chainId
+    (chainId : Bytes)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String PreparedNonCoinbaseTx := do
+  let core ← prepareNonCoinbaseTxCore txBytes utxoMap height blockTimestamp chainId rotDesc?
 
   let txid :=
     let r := RubinFormal.TxV2.parseTx txBytes
@@ -708,8 +719,10 @@ def applyNonCoinbaseTxBasicState
     (utxoMap : Std.RBMap Outpoint UtxoEntry cmpOutpoint)
     (height : Nat)
     (blockTimestamp : Nat)
-    (chainId : Bytes) : Except String (Nat × Std.RBMap Outpoint UtxoEntry cmpOutpoint) := do
-  let prepared ← prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId
+    (chainId : Bytes)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String (Nat × Std.RBMap Outpoint UtxoEntry cmpOutpoint) := do
+  let prepared ← prepareNonCoinbaseTxBasic txBytes utxoMap height blockTimestamp chainId rotDesc?
   pure (prepared.fee, prepared.nextUtxoMap)
 
 def applyNonCoinbaseTxBasic
@@ -717,8 +730,11 @@ def applyNonCoinbaseTxBasic
     (utxos : List (Outpoint × UtxoEntry))
     (height : Nat)
     (blockTimestamp : Nat)
-    (chainId : Bytes) : Except String (Nat × Nat) := do
-  let (fee, next) ← applyNonCoinbaseTxBasicState txBytes (buildUtxoMap utxos) height blockTimestamp chainId
+    (chainId : Bytes)
+    (rotDesc? : Option NativeSuiteRotation.RotationDeploymentDescriptor := none) :
+    Except String (Nat × Nat) := do
+  let (fee, next) ←
+    applyNonCoinbaseTxBasicState txBytes (buildUtxoMap utxos) height blockTimestamp chainId rotDesc?
   pure (fee, next.size)
 
 end UtxoBasicV1

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -1361,23 +1361,23 @@
       "section_heading": "## Spend Gate — Suite Acceptance Bridge",
       "status": "LIVE+BRIDGE",
       "theorems": [
-        "RubinFormal.SpendGateLiveBridge.spend_gate_live_equivalence",
-        "RubinFormal.SpendGateLiveBridge.gate_iff_live_suite_check",
-        "RubinFormal.SpendGateLiveBridge.spend_gate_phase1_bridge",
-        "RubinFormal.SpendGateLiveBridge.spend_gate_rejection_bridge"
+        "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_ok_constrained",
+        "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_rejects_inactive_suite",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_ok_constrained",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_rejects_inactive_p2pk_suite"
       ],
       "file": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
       "theorem_files": {
-        "RubinFormal.SpendGateLiveBridge.spend_gate_live_equivalence": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
-        "RubinFormal.SpendGateLiveBridge.gate_iff_live_suite_check": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
-        "RubinFormal.SpendGateLiveBridge.spend_gate_phase1_bridge": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
-        "RubinFormal.SpendGateLiveBridge.spend_gate_rejection_bridge": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean"
+        "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_ok_constrained": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
+        "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_rejects_inactive_suite": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_ok_constrained": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_rejects_inactive_p2pk_suite": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean"
       },
-      "notes": "Bridge theorems proving equivalence between the abstract spend-gate model and live suite-check functions on the pre-rotation surface. Auxiliary model theorems may strengthen the spend/create gate characterization, but the counted row remains the pre-rotation LIVE+BRIDGE closure only.",
+      "notes": "Universal closure of the descriptor-aware spend-side live gate bridge. validateP2PKSpendPreSig_ok_constrained and scanSingleInputStep_ok_constrained prove that, once the same preceding live structural guards have passed, the live P2PK spend helper and the live input-scan P2PK branch succeed iff the committed suite is active in NativeSpendSuites(h,d). Paired rejection theorems fix the exact inactive-suite live errors.",
       "limitations": [
-        "Pre-rotation scope only; post-rotation suite registry dispatch not yet bridged."
+        "Scope: descriptor-aware P2PK spend-side live gate bridge only; create-side gate and other spend validators are tracked in separate rows."
       ],
-      "evidence_level": "machine_checked_behavioral"
+      "evidence_level": "machine_checked_universal"
     },
     {
       "section_key": "feature_activation_fsm",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -302,6 +302,29 @@
       ]
     },
     {
+      "op": "spend_gate_bridge",
+      "gate": "descriptor-aware P2PK spend gate",
+      "model_theorem": "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_ok_constrained",
+      "lean_file": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
+      "theorem_file": "rubin-formal/RubinFormal/SpendGateLiveBridge.lean",
+      "evidence_level": "machine_checked_universal",
+      "spec_section": "§5.4 / §4.1.2",
+      "go_function": "validateP2PKSpendPreSig / scanSingleInputStep",
+      "contract_scope": "Universal closure of the descriptor-aware P2PK spend-side live gate bridge. Under the same preceding live structural guards, validateP2PKSpendPreSig and the P2PK branch of scanSingleInputStep succeed iff the committed suite is in NativeSpendSuites(h,d); inactive suites reject with the exact live error codes.",
+      "notes": "Universal closure of the live post-rotation spend gate bridge on the descriptor-aware P2PK spend path. The counted closure is the direct spend helper plus the input-scan gate; FI-ROT-04/FI-ROT-06 model theorems remain supporting evidence rather than the counted closure itself.",
+      "limitations": [
+        "Scope: descriptor-aware P2PK spend-side live gate bridge only; create-side gate and other spend validators are tracked separately."
+      ],
+      "supporting_theorems": [
+        "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_rejects_inactive_suite",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_ok_constrained",
+        "RubinFormal.SpendGateLiveBridge.scanSingleInputStep_rejects_inactive_p2pk_suite",
+        "RubinFormal.NativeSpendCreateGate.fi_rot_04_spend_gate_iff",
+        "RubinFormal.LegacySunset.fi_rot_06_old_suite_rejected_after_h4",
+        "RubinFormal.LegacySunset.fi_rot_06_new_suite_always_spendable_after_h4"
+      ]
+    },
+    {
       "op": "native_rotation",
       "gate": "FI-ROT",
       "model_theorem": "RubinFormal.NativeRegistryResolution.native_rotation_ok_constrained",


### PR DESCRIPTION
## Summary

Upgrades `spend_gate_bridge` to `machine_checked_universal` on the real descriptor-aware P2PK spend path by wiring the spend gate into the live Lean spend path itself.

## Formal Verification Checklist

> **Mandatory for any PR touching `.lean` files. Do not skip.**

### Invariant completeness

- [x] For every `def ... : Prop` — all constraints from the canonical spec are included (§5.4 witness suite gating, §4.1.2 rotation phases)
- [x] For every `≠` / `∉` / bound in a theorem hypothesis — verified that it **cannot** be derived from existing invariants. If it can → strengthen the invariant, don't add a separate hypothesis
- [x] If a theorem requires `h : X ≠ Y` but X comes from a structure that should guarantee this — the structure's well-formedness predicate is incomplete. **Fix the predicate first.**

### Soundness

- [x] 0 `sorry` / `admit` in all changed files
- [x] 0 new `axiom` (or justified in PR description why axiom is necessary)
- [x] All theorem statements match canonical spec semantics (§5.4 / §4.1.2)
- [x] `lake env lean` PASS on every changed `.lean` file

### Proof quality

- [x] No `native_decide` on universally quantified theorems (use structural proofs)
- [x] `native_decide` only for concrete/finite checks (`utxo_suite_eq_canonical` — specific constant equality)
- [x] Private helpers that encode security invariants are public (accessible to downstream proofs)

## Spec references

- CANONICAL §5.4 — witness suite gating
- CANONICAL §4.1.2 — rotation phases (FI-ROT-04, FI-ROT-05, FI-ROT-06)

## What changed

- `UtxoApplyGenesisV1.validateP2PKSpendPreSig`
  - `rotDesc? = none` keeps the pre-rotation singleton `{ML_DSA_87}` (backward-compatible default)
  - `rotDesc? = some d` enforces `suite ∈ NativeSpendSuites(h,d)`
- `UtxoBasicV1.scanSingleInputStep` (and helpers `scanInputsGo`, `scanInputs`, `prepareNonCoinbaseTxCore`, `prepareNonCoinbaseTxBasic`, `applyNonCoinbaseTxBasicState`, `applyNonCoinbaseTxBasic`)
  - optional `rotDesc?` parameter threaded through the full call chain; `none` default preserves all existing behavior
- `NativeSpendCreateGate.liveSpendGateAllows` — bridge helper with `none`/`some` dispatch
- `NativeSpendCreateGate.fi_rot_05_create_gate_iff` — iff form for FI-ROT-05
- `FormalGap03.validateP2PKSpendPreSig_binds_pubkey` — updated to work with the new `validateP2PKSpendPreSig` signature on the `none` pre-rotation branch

## New live bridge theorems

Counted closure for the row:
- `validateP2PKSpendPreSig_ok_constrained`
- `validateP2PKSpendPreSig_rejects_inactive_suite`
- `scanSingleInputStep_ok_constrained`
- `scanSingleInputStep_rejects_inactive_p2pk_suite`

Supportive but not counted as the closure itself:
- `spend_create_gate_ok_constrained`
- `fi_rot_05_create_gate_iff`
- FI-ROT-04 / FI-ROT-06 model theorems

## Scope

**Universal for the descriptor-aware P2PK spend-side live gate bridge.**

This row now proves that, under the same preceding live structural guards:
- the live P2PK spend helper succeeds iff the committed suite is active in `NativeSpendSuites(h,d)`
- the live input-scan P2PK branch succeeds iff the committed suite is active in `NativeSpendSuites(h,d)`
- inactive suites reject with the exact live error codes (`TX_ERR_SIG_ALG_INVALID` for `validateP2PKSpendPreSig`; `TX_ERR_COVENANT_TYPE_INVALID` for `scanSingleInputStep`)

No claim here about:
- create-side gate closure as a counted live row
- threshold / HTLC / other spend validators beyond this scoped P2PK spend-gate surface

## Test evidence

- `lake build` — passes (CI: all steps green for head commit `9e14db7`)
- `python3 tools/check_formal_registry_truth.py` — passes
- Formal Proof Hygiene CI — success
- Claude Code Review CI — success
- No `sorry`/`admit` in any changed file