### PR TITLE
fix: lift sighash_v1 to assumption-backed

### DIFF
--- a/RubinFormal/Index.lean
+++ b/RubinFormal/Index.lean
@@ -63,6 +63,7 @@ import RubinFormal.GenesisRuleBehavioral
 import RubinFormal.CoinbaseBehavioral
 import RubinFormal.TxContextBehavioral
 import RubinFormal.ConnectBlockFull
+import RubinFormal.SighashAssumptionBridge
 import RubinFormal.PerTxStateMachine
 import RubinFormal.UtxoMapProperties
 import RubinFormal.FeatureActivationFSM

--- a/RubinFormal/SighashAssumptionBridge.lean
+++ b/RubinFormal/SighashAssumptionBridge.lean
@@ -1,0 +1,198 @@
+import RubinFormal.ConnectBlockFull
+
+/-!
+# Sighash Assumption Bridge (§12/§14)
+
+Closes the remaining honest ceiling gap for `sighash_v1`:
+
+- LIVE bridge the TxContext `allowed_sighash_set` gate wired through
+  `validateTxContextSighashGate` / `validateTxContextSighashWitness`
+- explicit reduction theorem: equal live `digestV1` outputs on distinct
+  preimages would require a SHA3-256 collision
+
+This is assumption-backed, not universal: the theorem reduces digest equality
+to SHA3 equality on distinct preimages but does not claim cryptographic
+impossibility by itself.
+-/
+
+namespace RubinFormal
+
+open SighashV1
+
+/-- `validateTxContextSighashGate` succeeds exactly on the live allowlist
+    predicate already proved exhaustive in `SighashV1.checkSighashPolicy`. -/
+theorem validateTxContextSighashGate_ok_iff
+    (allowedSet sighashType : UInt8) :
+    validateTxContextSighashGate allowedSet sighashType = .ok () ↔
+      SighashV1.checkSighashPolicy allowedSet sighashType = true := by
+  constructor
+  · intro hOk
+    by_cases hPolicy : SighashV1.checkSighashPolicy allowedSet sighashType = true
+    · exact hPolicy
+    · have hPolicyFalse : SighashV1.checkSighashPolicy allowedSet sighashType = false := by
+        cases hCheck : SighashV1.checkSighashPolicy allowedSet sighashType <;>
+          simp [hCheck] at hPolicy ⊢
+      cases hType : SighashV1.hasValidBaseType sighashType <;>
+        simp [validateTxContextSighashGate, hType, hPolicyFalse] at hOk
+  · intro hPolicy
+    have hValid : SighashV1.hasValidBaseType sighashType = true := by
+      cases hType : SighashV1.hasValidBaseType sighashType with
+      | false =>
+          simp [SighashV1.checkSighashPolicy, hType] at hPolicy
+      | true =>
+          rfl
+    simp [validateTxContextSighashGate, hValid, hPolicy]
+
+/-- Invalid base types are rejected before the allowlist branch runs. -/
+theorem validateTxContextSighashGate_invalid_base_rejects
+    (allowedSet sighashType : UInt8)
+    (hInvalid : SighashV1.hasValidBaseType sighashType = false) :
+    validateTxContextSighashGate allowedSet sighashType =
+      .error "TX_ERR_SIGHASH_TYPE_INVALID" := by
+  simp [validateTxContextSighashGate, hInvalid]
+
+/-- Valid base types that still fail the allowlist map to
+    `TX_ERR_SIG_ALG_INVALID`, preserving the live error ordering. -/
+theorem validateTxContextSighashGate_disallowed_rejects
+    (allowedSet sighashType : UInt8)
+    (hValid : SighashV1.hasValidBaseType sighashType = true)
+    (hDisallowed : SighashV1.checkSighashPolicy allowedSet sighashType = false) :
+    validateTxContextSighashGate allowedSet sighashType =
+      .error "TX_ERR_SIG_ALG_INVALID" := by
+  simp [validateTxContextSighashGate, hValid, hDisallowed]
+
+/-- Non-empty witness signatures expose their last byte as the live sighash
+    discriminator consumed by the TxContext gate. -/
+theorem extractTxContextSighashType_ok
+    (w : UtxoBasicV1.WitnessItem)
+    (hNonEmpty : 0 < w.signature.size) :
+    extractTxContextSighashType w =
+      .ok (w.signature.get! (w.signature.size - 1)) := by
+  have hNonZero : w.signature.size ≠ 0 := Nat.ne_of_gt hNonEmpty
+  simp [extractTxContextSighashType, hNonZero]
+
+/-- Empty signatures are rejected before any sighash-policy logic runs. -/
+theorem validateTxContextSighashWitness_empty_signature_rejects
+    (allowedSet : UInt8) (w : UtxoBasicV1.WitnessItem)
+    (hEmpty : w.signature.size = 0) :
+    validateTxContextSighashWitness allowedSet w =
+      .error "TX_ERR_SIG_INVALID" := by
+  simp [validateTxContextSighashWitness, extractTxContextSighashType, hEmpty]
+
+/-- The witness-wired TxContext gate succeeds exactly when the last witness
+    byte passes the live `allowed_sighash_set` policy. -/
+theorem validateTxContextSighashWitness_ok_iff
+    (allowedSet : UInt8) (w : UtxoBasicV1.WitnessItem)
+    (hNonEmpty : 0 < w.signature.size) :
+    validateTxContextSighashWitness allowedSet w = .ok () ↔
+      SighashV1.checkSighashPolicy allowedSet
+        (w.signature.get! (w.signature.size - 1)) = true := by
+  simp [validateTxContextSighashWitness, extractTxContextSighashType_ok, hNonEmpty,
+    validateTxContextSighashGate_ok_iff]
+
+/-- Empty signatures fail before base-type and allowlist rejection paths. -/
+theorem validateTxContextSighashWitness_invalid_base_rejects
+    (allowedSet : UInt8) (w : UtxoBasicV1.WitnessItem)
+    (hNonEmpty : 0 < w.signature.size)
+    (hInvalid : SighashV1.hasValidBaseType
+      (w.signature.get! (w.signature.size - 1)) = false) :
+    validateTxContextSighashWitness allowedSet w =
+      .error "TX_ERR_SIGHASH_TYPE_INVALID" := by
+  simpa [validateTxContextSighashWitness, extractTxContextSighashType_ok, hNonEmpty] using
+    (validateTxContextSighashGate_invalid_base_rejects
+      allowedSet (w.signature.get! (w.signature.size - 1)) hInvalid)
+
+/-- Witness-carried sighash bytes with a valid base type but disallowed policy
+    still map to `TX_ERR_SIG_ALG_INVALID`. -/
+theorem validateTxContextSighashWitness_disallowed_rejects
+    (allowedSet : UInt8) (w : UtxoBasicV1.WitnessItem)
+    (hNonEmpty : 0 < w.signature.size)
+    (hValid : SighashV1.hasValidBaseType
+      (w.signature.get! (w.signature.size - 1)) = true)
+    (hDisallowed : SighashV1.checkSighashPolicy allowedSet
+      (w.signature.get! (w.signature.size - 1)) = false) :
+    validateTxContextSighashWitness allowedSet w =
+      .error "TX_ERR_SIG_ALG_INVALID" := by
+  simpa [validateTxContextSighashWitness, extractTxContextSighashType_ok, hNonEmpty] using
+    (validateTxContextSighashGate_disallowed_rejects
+      allowedSet (w.signature.get! (w.signature.size - 1)) hValid hDisallowed)
+
+/-- Explicit live preimage builder for `digestV1`, factored only so the
+    assumption-backed reduction theorem can talk about distinct preimages
+    directly instead of leaving the SHA3 premise implicit in prose. -/
+def digestV1Preimage
+    (core : SighashV1.TxCoreForSighash)
+    (chainId : Bytes) (inputIndex inputValue : Nat) : Bytes :=
+  let inp :=
+    match core.inputs.get? inputIndex with
+    | some x => x
+    | none =>
+        {
+          prevTxid := ByteArray.empty
+          prevVoutLE := ByteArray.empty
+          sequenceLE := ByteArray.empty
+        }
+  let hashPrevouts :=
+    SHA3.sha3_256 (SighashV1.concatBytes (core.inputs.map (fun i => i.prevTxid ++ i.prevVoutLE)))
+  let hashSeq :=
+    SHA3.sha3_256 (SighashV1.concatBytes (core.inputs.map (fun i => i.sequenceLE)))
+  let hashOut :=
+    SHA3.sha3_256 (SighashV1.concatBytes core.outputsRaw)
+  SighashV1.sighashPrefix ++
+    chainId ++
+    SighashV1.u32le core.version ++
+    RubinFormal.bytes #[core.txKind] ++
+    SighashV1.u64le core.txNonce.toNat ++
+    SighashV1.hashOfDA core.txKind ++
+    hashPrevouts ++
+    hashSeq ++
+    SighashV1.u32le inputIndex ++
+    inp.prevTxid ++
+    inp.prevVoutLE ++
+    SighashV1.u64le inputValue ++
+    inp.sequenceLE ++
+    hashOut ++
+    SighashV1.u32le core.locktime
+
+/-- On the live success path, `digestV1` is exactly SHA3-256 over the explicit
+    executable preimage builder above. -/
+theorem digestV1_ok_eq_sha3_preimage
+    (tx chainId : Bytes) (inputIndex inputValue : Nat)
+    (core : SighashV1.TxCoreForSighash)
+    (hParse : SighashV1.parseTxCoreForSighash tx = .ok core)
+    (hInBounds : inputIndex < core.inputs.length) :
+    SighashV1.digestV1 tx chainId inputIndex inputValue =
+      .ok (SHA3.sha3_256 (digestV1Preimage core chainId inputIndex inputValue)) := by
+  unfold SighashV1.digestV1 digestV1Preimage
+  rw [hParse]
+  simp only [Except.bind, Bind.bind]
+  rw [if_neg (by omega)]
+  rfl
+
+/-- Equal live `digestV1` outputs on two distinct executable preimages reduce
+    to a SHA3-256 collision obligation. This is the honest assumption-backed
+    ceiling for the digest side of §12. -/
+theorem digestV1_output_collision_reduces_to_sha3_collision
+    (tx₁ tx₂ chainId₁ chainId₂ : Bytes)
+    (inputIndex₁ inputIndex₂ inputValue₁ inputValue₂ : Nat)
+    (core₁ core₂ : SighashV1.TxCoreForSighash)
+    (hParse₁ : SighashV1.parseTxCoreForSighash tx₁ = .ok core₁)
+    (hParse₂ : SighashV1.parseTxCoreForSighash tx₂ = .ok core₂)
+    (hInBounds₁ : inputIndex₁ < core₁.inputs.length)
+    (hInBounds₂ : inputIndex₂ < core₂.inputs.length)
+    (hDistinct :
+      digestV1Preimage core₁ chainId₁ inputIndex₁ inputValue₁ ≠
+      digestV1Preimage core₂ chainId₂ inputIndex₂ inputValue₂)
+    (hDigestEq :
+      SighashV1.digestV1 tx₁ chainId₁ inputIndex₁ inputValue₁ =
+      SighashV1.digestV1 tx₂ chainId₂ inputIndex₂ inputValue₂) :
+    SHA3.sha3_256 (digestV1Preimage core₁ chainId₁ inputIndex₁ inputValue₁) =
+      SHA3.sha3_256 (digestV1Preimage core₂ chainId₂ inputIndex₂ inputValue₂) ∧
+    digestV1Preimage core₁ chainId₁ inputIndex₁ inputValue₁ ≠
+      digestV1Preimage core₂ chainId₂ inputIndex₂ inputValue₂ := by
+  rw [digestV1_ok_eq_sha3_preimage tx₁ chainId₁ inputIndex₁ inputValue₁ core₁ hParse₁ hInBounds₁,
+    digestV1_ok_eq_sha3_preimage tx₂ chainId₂ inputIndex₂ inputValue₂ core₂ hParse₂ hInBounds₂] at hDigestEq
+  injection hDigestEq with hSha
+  exact ⟨hSha, hDistinct⟩
+
+end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -226,7 +226,7 @@
     {
       "section_key": "sighash_v1",
       "section_heading": "## 12. Sighash v1 (Normative)",
-      "status": "proved",
+      "status": "proved_with_axiom",
       "theorems": [
         "RubinFormal.Conformance.cv_sighash_vectors_pass",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective",
@@ -241,7 +241,15 @@
         "RubinFormal.selectHashPrevouts_invalid_returns_none",
         "RubinFormal.selectHashSequences_invalid_returns_none",
         "RubinFormal.selectHashOutputs_invalid_returns_none",
-        "RubinFormal.hasValidBaseType_exhaustive"
+        "RubinFormal.hasValidBaseType_exhaustive",
+        "RubinFormal.validateTxContextSighashGate_ok_iff",
+        "RubinFormal.validateTxContextSighashGate_invalid_base_rejects",
+        "RubinFormal.validateTxContextSighashGate_disallowed_rejects",
+        "RubinFormal.validateTxContextSighashWitness_ok_iff",
+        "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects",
+        "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects",
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects",
+        "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
@@ -257,16 +265,24 @@
         "RubinFormal.selectHashPrevouts_invalid_returns_none": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
         "RubinFormal.selectHashSequences_invalid_returns_none": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
         "RubinFormal.selectHashOutputs_invalid_returns_none": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
-        "RubinFormal.hasValidBaseType_exhaustive": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean"
+        "RubinFormal.hasValidBaseType_exhaustive": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
+        "RubinFormal.validateTxContextSighashGate_ok_iff": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashGate_invalid_base_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashGate_disallowed_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashWitness_ok_iff": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean"
       },
-      "notes": "Tautological digestV1_deterministic/ext removed from registry. 5 wrapper commits_* theorems removed (congrArg corollaries of injective). Substantive: 3 invalid-type rejections + hasValidBaseType exhaustive + buildPreimageFrameParts_injective + checkSighashPolicy_exhaustive_256x256 + 8 selectHash*/Output individual type theorems.",
+      "notes": "Counted core now combines the existing CV-SIGHASH replay + live selection theorems with the live TXCTX `allowed_sighash_set` gate/witness bridge and an explicit reduction theorem: equal live `digestV1` outputs on distinct executable preimages imply a SHA3-256 collision obligation. This is the honest assumption-backed ceiling for §12 without overclaiming arbitrary raw-tx equivalence.",
       "limitations": [
         "The executable digestV1 replay path still covers the current fixture subset and is not yet a universal tx-level equivalence proof for every §12 sighash_type branch or invalid-type rejection path.",
-        "The strengthened theorems are structural over pre-hashed components and segmented preimage parts, not a claim about cryptographic collision resistance of SHA3-256.",
-        "No universal proof is claimed here for deriving all hashed components directly from arbitrary raw transactions, DaCoreFieldsBytes, or witness-carried sighash_type extraction.",
-        "The TxContext-aware verify_sig_ext dispatch and allowed_sighash_set policy introduced by TXCTX are not yet covered by a dedicated section-level proof."
+        "The digest theorem is a reduction theorem: when two live digestV1 executions succeed with equal outputs and their executable preimages are distinct, SHA3-256 would have to collide. The proof does not itself claim cryptographic impossibility.",
+        "No universal proof is claimed here for deriving preimage distinctness from arbitrary raw transaction pairs, DaCoreFieldsBytes variation, or every witness-carried sighash_type path.",
+        "The TXCTX allowlist bridge now covers the live `validateTxContextSighashGate` / `validateTxContextSighashWitness` surface, but broader raw-tx/hash equivalence residuals remain out of scope."
       ],
-      "evidence_level": "machine_checked_contract"
+      "evidence_level": "machine_checked_assumption_backed"
     },
     {
       "section_key": "consensus_error_codes",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -22,14 +22,14 @@
       "model_theorem": "RubinFormal.Conformance.cv_sighash_vectors_pass",
       "lean_file": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
       "theorem_file": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
-      "evidence_level": "machine_checked_contract",
+      "evidence_level": "machine_checked_assumption_backed",
       "spec_section": "§12",
       "go_function": "DigestV1",
-      "contract_scope": "CV-SIGHASH replay plus substantive live sighash-selection rejection theorems on selectHashPrevouts/selectHashSequences/selectHashOutputs and exhaustive hasValidBaseType coverage. This closes the currently shipped fixture subset and the live invalid-type selection surface without claiming a universal tx-level digest equivalence theorem.",
+      "contract_scope": "CV-SIGHASH replay plus substantive live sighash-selection rejection theorems on selectHashPrevouts/selectHashSequences/selectHashOutputs, live TXCTX allowed_sighash_set bridge theorems on validateTxContextSighashGate/validateTxContextSighashWitness, and an explicit reduction theorem showing that equal live digestV1 outputs on distinct executable preimages would require a SHA3-256 collision.",
       "limitations": [
         "This remains a contract-level bridge: the executable replay covers the current CV-SIGHASH fixture set, not every possible raw transaction / witness-carried sighash_type combination.",
-        "No cryptographic injectivity claim over SHA3-256 digests is made here; buildPreimageFrameParts_injective reasons about frame parts, not collision resistance.",
-        "TXCTX-aware allowed_sighash_set policy is tracked in the separate §14 TxContext row, not claimed here as extra §12 bridge strength."
+        "The digest reduction theorem is assumption-backed: it turns equal live digests plus distinct executable preimages into a SHA3-256 collision obligation, but it does not itself prove such collisions impossible.",
+        "No universal proof is claimed here for deriving preimage distinctness from arbitrary raw transaction pairs, DaCoreFieldsBytes variation, or every witness-carried sighash_type combination."
       ],
       "supporting_theorems": [
         "RubinFormal.sighash_v1_proved",
@@ -46,9 +46,17 @@
         "RubinFormal.selectHashPrevouts_invalid_returns_none",
         "RubinFormal.selectHashSequences_invalid_returns_none",
         "RubinFormal.selectHashOutputs_invalid_returns_none",
-        "RubinFormal.hasValidBaseType_exhaustive"
+        "RubinFormal.hasValidBaseType_exhaustive",
+        "RubinFormal.validateTxContextSighashGate_ok_iff",
+        "RubinFormal.validateTxContextSighashGate_invalid_base_rejects",
+        "RubinFormal.validateTxContextSighashGate_disallowed_rejects",
+        "RubinFormal.validateTxContextSighashWitness_ok_iff",
+        "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects",
+        "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects",
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects",
+        "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision"
       ],
-      "notes": "Bridge upgraded from baseline because the shared-op surface now has both executable CV-SIGHASH replay and substantive live theorems on the real sighash helper functions. This is still an honest contract lane, not a universal claim for every raw tx / witness path."
+      "notes": "Bridge upgraded from contract to assumption-backed because the section now includes both the live TXCTX allowlist surface and an explicit digest-collision reduction theorem. The result is still honest about residual raw-tx/preimage distinctness gaps and does not overclaim universal tx-level digest equivalence."
     },
     {
       "op": "retarget_v1",


### PR DESCRIPTION
## Summary

- add live TXCTX `allowed_sighash_set` bridge theorems for `validateTxContextSighashGate` and `validateTxContextSighashWitness`
- add an explicit reduction theorem showing equal live `digestV1` outputs on distinct executable preimages would require a SHA3-256 collision
- raise `sighash_v1` from `machine_checked_contract` to `machine_checked_assumption_backed` in the formal registries

## Formal Verification Checklist

> **Mandatory for any PR touching `.lean` files. Do not skip.**

### Invariant completeness

- [x] For every `def ... : Prop` — all constraints from the canonical spec are included (§12 sighash gate + witness surface)
- [x] For every `≠` / `∉` / bound in a theorem hypothesis — `hDistinct` in `digestV1_output_collision_reduces_to_sha3_collision` cannot be derived from existing invariants; it is a required input to the reduction
- [x] If a theorem requires `h : X ≠ Y` but X comes from a structure that should guarantee this — not applicable here; `digestV1Preimage` is an explicit preimage builder, not a well-formedness predicate

### Soundness

- [x] 0 `sorry` / `admit` in all changed files
- [x] 0 new `axiom` — this PR is assumption-backed in the evidence-level sense, not via new Lean axioms
- [x] All theorem statements match canonical spec semantics — `validateTxContextSighashGate`/`validateTxContextSighashWitness` wired to live `checkSighashPolicy` (§12/§14); collision theorem honestly scoped as a reduction, not a cryptographic impossibility claim
- [x] `lake env lean` PASS on every changed `.lean` file

### Proof quality

- [x] No `native_decide` on universally quantified theorems in new file
- [x] Existing `native_decide` in `SighashV1.lean` is for the concrete 256×256 exhaustive closure — unchanged
- [x] `digestV1_ok_eq_sha3_preimage` and `extractTxContextSighashType_ok` are public helpers accessible to downstream proofs

## Spec references

- §12 Sighash v1 (Normative) — `validateTxContextSighashGate`, `validateTxContextSighashWitness`, `digestV1` preimage and collision reduction
- §14 TxContext — `allowed_sighash_set` policy bridge

## Test evidence

- `lake build` — PASS
- `python3 tools/check_formal_registry_truth.py` — 142 Python unit tests OK