### PR TITLE
fix: upgrade transaction identifiers to assumption-backed

### DIFF
--- a/RubinFormal/PinnedSections.lean
+++ b/RubinFormal/PinnedSections.lean
@@ -5,6 +5,7 @@ import RubinFormal.CoreExtInvariants
 import RubinFormal.SighashV1
 import RubinFormal.CovenantGenesisV1
 import RubinFormal.WitnessCommitmentV1
+import RubinFormal.TxIdBehavioral
 
 namespace RubinFormal
 
@@ -18,12 +19,22 @@ def transactionWireStatement : Prop :=
     ByteWireLegacy.parseCompactSizeToy (ByteWireLegacy.encodeCompactSizeToy n) = some (n, [])) ∧
   (∀ tx : ByteWireLegacy.TxMini, ByteWireLegacy.txMiniByteValid tx →
     ByteWireLegacy.parseTxMini (ByteWireLegacy.serializeTxMini tx) = some tx)
-/-- v2 (F-01 fix): ByteArray preimage distinctness for txid ≠ wtxid.
-    When witness is non-empty (coreEnd < tx.size), the txid preimage
-    (tx.extract 0 coreEnd) differs from the wtxid preimage (full tx). -/
+/-- §8 identifier boundary surface.
+    (1) `TxCoreBytes` and `TxBytes` are structurally distinct for every
+        serialized transaction because the full wire encoding always retains
+        witness-count / payload-length markers after the core bytes.
+    (2) The witness-empty lane is covered explicitly: the full bytes still carry
+        a `CompactSize(0)` witness-count marker before the DA payload length. -/
 def transactionIdentifiersStatement : Prop :=
-  ∀ (tx : ByteArray) (coreEnd : Nat),
-    coreEnd < tx.size → tx.extract 0 coreEnd ≠ tx
+  (∀ tx : UtxoBasicV1.Tx,
+    UtxoBasicV1.serializeTxCore tx ≠ UtxoBasicV1.serializeTx tx) ∧
+  (∀ tx : UtxoBasicV1.Tx,
+    tx.witness = [] →
+      UtxoBasicV1.serializeTx tx =
+        UtxoBasicV1.serializeTxCore tx ++
+          RubinFormal.WireEnc.compactSize 0 ++
+          RubinFormal.WireEnc.compactSize tx.daPayloadLen ++
+          tx.daPayload)
 def weightAccountingStatement : Prop :=
   ∀ base witness1 witness2 sigCost : Nat, witness1 ≤ witness2 → weight base witness1 sigCost ≤ weight base witness2 sigCost
 /-- v3 (D08-F02 fix): standalone witness-commitment semantics.
@@ -186,8 +197,11 @@ theorem transaction_wire_proved : transactionWireStatement := by
     exact ByteWireLegacy.parse_serializeTxMini_roundtrip tx htx
 
 theorem transaction_identifiers_proved : transactionIdentifiersStatement := by
-  intro tx coreEnd h
-  exact txid_wtxid_preimage_bytes_distinct tx coreEnd h
+  refine ⟨?_, ?_⟩
+  · intro tx
+    exact txid_wtxid_payloads_distinct tx
+  · intro tx hEmpty
+    exact txid_wtxid_witness_empty_serialization_shape tx hEmpty
 
 theorem weight_accounting_proved : weightAccountingStatement := by
   intro base witness1 witness2 sigCost hw

--- a/RubinFormal/TxIdBehavioral.lean
+++ b/RubinFormal/TxIdBehavioral.lean
@@ -1,6 +1,12 @@
 import RubinFormal.CriticalInvariants
 import RubinFormal.MerkleV2
 import RubinFormal.MerkleStructure
+import RubinFormal.UtxoBasicV1
+import RubinFormal.TxWirePrefixLemmas
+import RubinFormal.TxWireRoundtrip
+import Std.Tactic.Omega
+
+set_option maxHeartbeats 8000000
 
 /-!
 # TXID/WTXID Behavioral Proofs (§8)
@@ -11,6 +17,7 @@ Proves domain tag separation for TXID and WTXID merkle tree construction.
 namespace RubinFormal
 
 open Merkle
+open UtxoBasicV1
 
 /-- TXID leaf tag (0x00) differs from WTXID leaf tag (0x02). -/
 theorem txid_wtxid_tag_distinct :
@@ -30,25 +37,76 @@ theorem all_merkle_tags_distinct :
     (0x01 : UInt8) ≠ 0x02 ∧ (0x01 : UInt8) ≠ 0x03 ∧
     (0x02 : UInt8) ≠ 0x03 := by native_decide
 
--- txid_wtxid_preimage_bytes_distinct already proved in CriticalInvariants.lean
+/-- CompactSize always emits at least one byte. -/
+private theorem compactSize_size_pos (n : Nat) :
+    0 < (RubinFormal.WireEnc.compactSize n).size := by
+  by_cases h1 : n < 0xfd
+  · rw [compactSize_size_one n h1]
+    decide
+  · by_cases h2 : n ≤ 0xffff
+    · rw [compactSize_size_three n h1 h2]
+      decide
+    · by_cases h3 : n ≤ 0xffffffff
+      · rw [compactSize_size_five n h1 h2 h3]
+        decide
+      · rw [compactSize_size_nine n h1 h2 h3]
+        decide
 
-/-- For transactions with a non-empty witness section, the actual txid preimage
-    bytes (`tx.extract 0 coreEnd`) differ from the full-transaction wtxid
-    preimage bytes (`tx`). This is the non-fixture structural core of §8. -/
-theorem txid_wtxid_payloads_distinct_when_witness_present
-    (tx : ByteArray) (coreEnd : Nat) (h : coreEnd < tx.size) :
-    tx.extract 0 coreEnd ≠ tx := by
-  exact txid_wtxid_preimage_bytes_distinct tx coreEnd h
+/-- Witness serialization always contributes at least the witness-count CompactSize byte,
+    even when the witness list is empty. -/
+private theorem serializeWitness_size_pos (wit : List WitnessItem) :
+    0 < (serializeWitness wit).size := by
+  unfold serializeWitness
+  rw [ByteArray.size_append]
+  have hCount : 0 < (RubinFormal.WireEnc.compactSize wit.length).size :=
+    compactSize_size_pos wit.length
+  omega
 
-/-- Section-level contract for identifier-domain separation:
-    when witness is present, the raw txid and wtxid payloads already diverge,
-    and the tagged leaf-preimage domains used by the Merkle layer are disjoint. -/
+private theorem bytes_empty_append (bs : Bytes) : ByteArray.empty ++ bs = bs := by
+  apply ByteArray.ext
+  simp [ByteArray.append_data, ByteArray.empty_data, Array.nil_append]
+
+/-- The txid preimage (`TxCoreBytes`) and the wtxid preimage (`TxBytes`) are
+    structurally distinct for every serialized transaction, because the full
+    wire encoding always retains at least the witness-count and payload-length
+    CompactSize markers after the core bytes. -/
+theorem txid_wtxid_payloads_distinct (tx : Tx) :
+    serializeTxCore tx ≠ serializeTx tx := by
+  apply bytearray_ne_of_size_lt
+  unfold serializeTxCore serializeTx serializeTxAfterNonce serializeWitness
+  repeat rw [ByteArray.size_append]
+  have hWitnessCount : 0 < (RubinFormal.WireEnc.compactSize tx.witness.length).size :=
+    compactSize_size_pos tx.witness.length
+  have hDaLen : 0 < (RubinFormal.WireEnc.compactSize tx.daPayloadLen).size :=
+    compactSize_size_pos tx.daPayloadLen
+  omega
+
+/-- Witness-empty transactions are still serialized with an explicit
+    `CompactSize(0)` witness-count marker before the DA payload length field. -/
+theorem txid_wtxid_witness_empty_serialization_shape
+    (tx : Tx) (hEmpty : tx.witness = []) :
+    serializeTx tx =
+      serializeTxCore tx ++
+        RubinFormal.WireEnc.compactSize 0 ++
+        RubinFormal.WireEnc.compactSize tx.daPayloadLen ++
+        tx.daPayload := by
+  simp [serializeTx, serializeTxCore, serializeTxAfterNonce,
+    serializeWitness, serializeWitnessItems, concatBytes,
+    cursor_bytes_left_assoc, hEmpty, bytes_empty_append]
+
+/-- Section-level identifier-domain contract:
+    the canonical txid and wtxid preimages are structurally distinct for every
+    serialized transaction, and the tagged Merkle leaf-preimage domains remain
+    disjoint. Distinct digests across those distinct preimages remain an explicit
+    SHA3 assumption boundary. -/
 theorem txid_wtxid_identifier_domain_contract
-    (tx : ByteArray) (coreEnd : Nat) (h : coreEnd < tx.size) :
-    tx.extract 0 coreEnd ≠ tx ∧
-    Merkle.txidLeafPreimage (tx.extract 0 coreEnd) ≠ Merkle.wtxidLeafPreimage tx := by
+    (tx : Tx) :
+    serializeTxCore tx ≠ serializeTx tx ∧
+    Merkle.txidLeafPreimage (serializeTxCore tx) ≠
+      Merkle.wtxidLeafPreimage (serializeTx tx) := by
   constructor
-  · exact txid_wtxid_payloads_distinct_when_witness_present tx coreEnd h
-  · exact Merkle.merkle_tag_equivalence_leaf_domains_disjoint (tx.extract 0 coreEnd) tx
+  · exact txid_wtxid_payloads_distinct tx
+  · exact Merkle.merkle_tag_equivalence_leaf_domains_disjoint
+      (serializeTxCore tx) (serializeTx tx)
 
 end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -109,20 +109,21 @@
         "RubinFormal.Conformance.cv_parse_vectors_pass",
         "RubinFormal.Conformance.cv_sig_vectors_pass",
         "RubinFormal.transaction_identifiers_proved",
+        "RubinFormal.txid_wtxid_witness_empty_serialization_shape",
         "RubinFormal.txid_wtxid_identifier_domain_contract"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.transaction_identifiers_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
+        "RubinFormal.txid_wtxid_witness_empty_serialization_shape": "rubin-formal/RubinFormal/TxIdBehavioral.lean",
         "RubinFormal.txid_wtxid_identifier_domain_contract": "rubin-formal/RubinFormal/TxIdBehavioral.lean"
       },
-      "evidence_level": "machine_checked_contract",
+      "evidence_level": "machine_checked_assumption_backed",
       "limitations": [
-        "This remains a contract-level section: the non-fixture theorem surface proves preimage/domain separation for the witness-present path, while CV-PARSE/CV-SIG replay covers concrete emitted txid/wtxid outputs on the shipped fixtures.",
-        "No universal claim is made that SHA3(tx.extract 0 coreEnd) and SHA3(tx) differ as digests for every raw transaction; that would require an explicit cryptographic collision-resistance assumption beyond the current structural proofs.",
-        "Witness-empty transactions still rely on the executable replay path for concrete txid=wtxid behavior; this row does not claim a full end-to-end theorem over every parse path in TxParseV2."
+        "The non-fixture theorem surface now proves the structural preimage boundary for canonical serializer outputs, including the witness-empty lane, but concluding digest inequality / identifier uniqueness from those distinct preimages still relies on explicit SHA3-256 collision and second-preimage resistance assumptions.",
+        "CV-PARSE and CV-SIG replay remain the executable evidence that the current parser emits the pinned txid/wtxid bytes on shipped fixtures; the theorem surface does not replace fixture replay for concrete digest values."
       ],
-      "notes": "Section §8 is no longer replay-only: `transaction_identifiers_proved` restores the real-byte preimage distinctness theorem from `PinnedSections/CriticalInvariants`, and `txid_wtxid_identifier_domain_contract` adds a section-local contract theorem tying those payload bytes to the actual txid/wtxid Merkle leaf domains. CV-PARSE and CV-SIG replay remain the executable evidence for concrete emitted txid/wtxid values."
+      "notes": "Section §8 is now honest assumption-backed evidence: `transaction_identifiers_proved` lifts the section statement onto the live canonical serializer boundary (`serializeTxCore` vs `serializeTx`), `txid_wtxid_witness_empty_serialization_shape` closes the witness-empty lane explicitly via the retained `CompactSize(0)` marker, and `txid_wtxid_identifier_domain_contract` keeps the Merkle leaf domains disjoint. CV-PARSE and CV-SIG replay remain the executable evidence for concrete emitted txid/wtxid values."
     },
     {
       "section_key": "weight_accounting",


### PR DESCRIPTION
## Summary

- lift `transaction_identifiers` from `machine_checked_contract` to `machine_checked_assumption_backed`
- prove the live canonical serializer boundary `serializeTxCore tx ≠ serializeTx tx` for every `Tx`
- close the witness-empty lane explicitly via retained `CompactSize(0)` witness-count serialization
- keep digest inequality / identifier uniqueness as explicit SHA3 assumption boundary

## Formal Verification Checklist

> **Mandatory for any PR touching `.lean` files. Do not skip.**

### Invariant completeness

- [x] For every `def ... : Prop` — all constraints from the canonical spec are included (`§8` identifier boundary, witness-empty lane, SHA3 assumption boundary)
- [x] For every `≠` / `∉` / bound in a theorem hypothesis — `serializeTxCore tx ≠ serializeTx tx` is derived structurally from size arithmetic; no separate hypothesis needed
- [x] No well-formedness predicate gaps introduced; distinctness follows from `serializeTx` always appending at least `compactSize(witness.length)` + `compactSize(daPayloadLen)` bytes beyond the core

### Soundness

- [x] 0 `sorry` / `admit` in all changed files
- [x] 0 new `axiom` — digest inequality remains an explicit SHA3 collision-resistance assumption boundary (documented in `proof_coverage.json` limitations)
- [x] All theorem statements match canonical spec §8 semantics
- [x] `lake env lean` PASS on every changed `.lean` file

### Proof quality

- [x] No `native_decide` on universally quantified theorems — `txid_wtxid_payloads_distinct` and `txid_wtxid_witness_empty_serialization_shape` use structural `omega` / `simp` proofs
- [x] `native_decide` retained only for concrete tag-distinctness checks (`txid_wtxid_tag_distinct`, `all_merkle_tags_distinct`)
- [ ] **Note**: `serializeWitness_size_pos` is a private helper defined in `TxIdBehavioral.lean` but is currently unused (dead code); can be removed in a follow-up

## Spec references

- `RUBIN_L1_CANONICAL.md §8` — transaction identifier boundary: `txid = SHA3(TxCoreBytes)`, `wtxid = SHA3(TxBytes)`, `TxBytes` retains witness-count and payload-length markers even when witness is empty

## Test evidence

- `lake build` — passes
- `python3 tools/check_formal_registry_truth.py` — passes (142 Python tests OK)
- All changed theorems verified by Lean kernel; `proof_coverage.json` evidence level updated to `machine_checked_assumption_backed`