### PR TITLE
docs: correct post-uplift formal truth narrative

### DIFF
--- a/PROOF_COVERAGE.md
+++ b/PROOF_COVERAGE.md
@@ -1,11 +1,11 @@
-# Proof Coverage (bootstrap)
+# Proof Coverage
 
 Источник: `spec/SECTION_HASHES.json`  
 Машинный реестр: `rubin-formal/proof_coverage.json`
 
 Текущее состояние: machine-readable source-of-truth (`proof_coverage.json`) фиксирует
-`proof_level=refinement`, `claim_level=refined`, полный registry по 17 pinned section keys и явные
-`notes` / `limitations` для thin или partial entries. Conformance-фикстуры
+`proof_level=refinement`, `claim_level=refined`, полный registry по 24 current section entries и явные
+`notes` / `limitations` для non-universal claims. Conformance-фикстуры
 `conformance/fixtures/CV-*.json` покрыты Lean replay/refinement слоем.
 
 ## Термины (важно)
@@ -16,26 +16,33 @@
   - `toy` (только model-baseline),
   - `byte` (byte-accurate слой),
   - `refined` (refinement to executable path).
-- `status=proved/proved_with_axiom/stated/deferred` относится к конкретной pinned-секции **в рамках указанного `proof_level`**.
+- `status=proved/proved_with_axiom` относится к конкретной registry entry **в рамках указанного `proof_level`**.
 - `status=proved_with_axiom` означает: proof закрывает секцию, но опирается на явно названные криптографические или модельные допущения, поэтому честный ceiling такой записи — `machine_checked_assumption_backed`, а не unconditional `universal`.
+- `evidence_level` — главный public-facing taxonomy field. Именно он различает universal / behavioral / assumption-backed / contract-level ceiling.
 
 Внешний аудит / freeze-ready коммуникации **НЕ ДОЛЖНЫ** трактовать текущий `proof_level=refinement`
 как “formal verification of CANONICAL for all inputs/sections”.
 
 Связка с hash-pinning:
 
-- `spec/SECTION_HASHES.json` сейчас содержит 17 pinned section keys.
-- `proof_coverage.json` теперь явно отслеживает все 17 ключей.
-- Не все 17 entries равны по силе claims: часть оставлена как `stated`, а часть `proved`
-  дополнительно ограничена `notes` / `limitations`.
+- `proof_coverage.json` сейчас содержит 24 machine-checked registry entries.
+- Все 24 текущие entries уже machine-checked; активных `stated` / `deferred` rows сейчас нет.
+- Не все 24 entries равны по силе claims: честная граница определяется `evidence_level` и `limitations`.
 - Extra formal-only theorems (например, `CORE_EXT` tightening) не считаются pinned-section coverage,
   если они не внесены отдельной registry entry.
 
+## Текущая раскладка evidence levels
+
+- `machine_checked_universal`: 18
+- `machine_checked_assumption_backed`: 3
+- `machine_checked_behavioral`: 2
+- `machine_checked_contract`: 1
+
 ## Путь к freeze-ready
 
-1. Углубить `stated` entries и scope-limited `proved` entries до более сильных секционных теорем.
-2. Углубить доказательства beyond-fixtures для consensus-critical safety-инвариантов.
-3. Держать матрицу покрытия в синхроне с hash-pinning CANONICAL и narrative в spec docs.
+1. Держать матрицу покрытия в синхроне с public narrative и closeout evidence.
+2. Углублять non-universal entries там, где это реально снижает consensus-risk или audit ambiguity.
+3. Не смешивать truth-correction с отдельными hygiene lanes вроде theorem traceability.
 
 ## Risk scoring / gates
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# RUBIN Formal (Lean4) — bootstrap
+# RUBIN Formal (Lean4)
 
-Этот каталог содержит in-repo formal proof-pack baseline для RUBIN.
+Этот репозиторий содержит machine-checked formal proof surface для RUBIN.
 
 ## Что есть сейчас
 
 - Lean4-пакет `RubinFormal`
-- `proof_coverage.json` с machine-readable coverage registry по всем 17 pinned section keys
-- formal registry entries со статусами `proved` / `stated` и явными `notes` / `limitations` там, где claim scope уже не тянет на полное секционное доказательство
+- `proof_coverage.json` с machine-readable coverage registry по 24 текущим section entries
+- formal registry entries с явным `evidence_level`, `notes` и `limitations`, чтобы публичные claims не обгоняли реальную границу доказательств
 
 ## Граница claims (критично)
 
-Этот proof-pack — executable replay/refinement coverage для conformance-фикстур (CV-*.json) и baseline-слой
-для дальнейшей формализации. Он нужен для воспроизводимого “якоря”, но **не** является универсальной
-формальной верификацией CANONICAL.
+Этот proof-pack — executable replay/refinement surface для conformance-фикстур (CV-*.json) и live Lean theorems
+по части секций. Он даёт reproducible machine-checked evidence, но **не** является универсальной
+формальной верификацией всего CANONICAL.
 Текущий machine-readable статус: `proof_level=refinement`, `claim_level=refined`.
 
 Разрешённые формулировки (OK):
 
 - "Lean executable semantics replay all conformance fixtures (CV-*.json)"
 - "Go(reference) → Lean refinement is checked for critical ops over conformance fixture set"
-- "Pinned-section coverage is machine-readable, but some section entries are intentionally `stated` or explicitly scope-limited"
+- "Pinned-section coverage is machine-readable with explicit evidence levels: universal, behavioral, assumption-backed, and contract-level"
 
 Запрещённые формулировки (NOT OK):
 
@@ -45,9 +45,9 @@
 
 - Это **не** полный freeze-ready пакет уровня "универсальная байтовая модель wire + state transition для всех секций".
 - Консенсусные правила не меняются.
-- Формальный coverage registry сейчас явно отражает все 17 pinned section keys.
-- Не все 17 записей имеют одинаковую силу: часть entries остаётся `stated`, а часть `proved` entries
-  дополнительно ограничена `notes` / `limitations` в `proof_coverage.json`.
+- Формальный coverage registry сейчас содержит 24 machine-checked section entries.
+- По силе claims текущая раскладка такая: `18` universal, `3` assumption-backed, `2` behavioral, `1` contract-level.
+- Единый статус `proved` в registry не означает одинаковую силу claim: честная граница задаётся `evidence_level` и `limitations` в `proof_coverage.json`.
 - Extra formal-only theorems не считаются pinned-section claims, если они не внесены в machine-readable registry.
 
 ## Локальный запуск
@@ -66,6 +66,6 @@ cd ../rubin-protocol && scripts/dev-env.sh -- bash -lc 'cd ../rubin-formal && la
 
 ## Дальше
 
-1. Углубить `stated` entries и scope-limited `proved` entries до более сильных секционных теорем там, где это действительно нужно.
-2. Поддерживать `proof_coverage.json` в синхроне со `spec/SECTION_HASHES.json` и narrative в `rubin-spec`.
-3. Не поднимать formal-only extra theorems в публичные pinned-section claims без явного registry update.
+1. Поддерживать `proof_coverage.json`, public narrative и closeout evidence в синхроне.
+2. Не поднимать formal-only extra theorems в публичные pinned-section claims без явного registry update.
+3. Отдельно добрать theorem-level traceability (`theorem_refs`) как самостоятельный hygiene/improvement трек, не смешивая его с truth-correction.

--- a/RISK_MODEL.md
+++ b/RISK_MODEL.md
@@ -17,8 +17,9 @@
 - **Pinned section**: секция из `spec/SECTION_HASHES.json`, которая hash‑pin’ится и должна быть синхронна со спекой.
 - `status=proved`: утверждения для pinned‑секции доказаны в рамках текущего `proof_level`.
 - `status=proved_with_axiom`: утверждения доказаны, но proof опирается на один или более явно названных допущений. Для hash/commitment-секций это обычно означает reduction к collision resistance, а не аксиомо-свободную невозможность коллизии.
-- `status=stated`: утверждения сформулированы как леммы/аксиомы, но доказательства не добавлены.
-- `status=deferred`: секция сознательно не покрыта формально на данном этапе.
+- `status=stated`: резервный статус для будущих registry rows без machine-checked доказательства. В текущем registry таких строк нет.
+- `status=deferred`: резервный статус для сознательно не покрытой секции. В текущем registry таких строк нет.
+- `evidence_level`: главный truth-correction field для честного public claim ceiling. Он отделяет universal, behavioral, assumption-backed и contract-level entries даже когда registry status уже `proved`.
 
 ## Уровни доказательств (`proof_level`)
 
@@ -58,6 +59,19 @@
 Минимальный “freeze‑adjacent” профиль:
 - `proof_level ∈ {byte-model, refinement}`;
 - `stated=0` и `deferred=0`.
+
+## Текущая truth snapshot
+
+На текущем refinement-срезе registry содержит:
+
+- `18` universal entries;
+- `3` assumption-backed entries;
+- `2` behavioral entries;
+- `1` contract-level entry;
+- `0` stated rows;
+- `0` deferred rows.
+
+Это сильнее старого bootstrap narrative, но всё ещё не даёт права заявлять universal proof of full CANONICAL semantics.
 
 ## Risk scoring (информативно)
 

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -1378,7 +1378,7 @@
     {
       "section_key": "spend_gate_bridge",
       "section_heading": "## Spend Gate — Suite Acceptance Bridge",
-      "status": "LIVE+BRIDGE",
+      "status": "proved",
       "theorems": [
         "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_ok_constrained",
         "RubinFormal.SpendGateLiveBridge.validateP2PKSpendPreSig_rejects_inactive_suite",
@@ -1401,7 +1401,7 @@
     {
       "section_key": "feature_activation_fsm",
       "section_heading": "## Feature Activation FSM (BIP9-like)",
-      "status": "LIVE+BRIDGE",
+      "status": "proved",
       "theorems": [
         "RubinFormal.active_terminal",
         "RubinFormal.failed_terminal",
@@ -1443,9 +1443,9 @@
   "proof_level": "refinement",
   "claims": {
     "allowed": [
-      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; this is not a universal proof of CANONICAL semantics",
+      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; the registry now records 24 machine-checked section entries, but this is still not a universal proof of full CANONICAL semantics",
       "Go(reference) → Lean refinement is checked for critical ops over the full conformance fixture set (trace schema v1)",
-      "The pinned-section registry covers all 17 hash-pinned section keys. Each entry carries an explicit evidence_level distinguishing universal proofs from subset contracts, assumption-backed proofs, and CV-replay-only entries.",
+      "The pinned-section registry currently covers 24 section entries. Each entry carries an explicit evidence_level distinguishing universal proofs, behavioral proofs, assumption-backed proofs, and contract-level fixture coverage.",
       "formal claims are bounded by explicit forbidden claims below",
       "Bridge theorems (LIVE/BRIDGE class) prove properties of Lean transcriptions of Go/Rust functions. Lean-to-Go/Rust parity is verified by human code review, not machine-checked. The behavioral claim applies to the Lean transcription; transfer to Go/Rust binary relies on the reviewed parity."
     ],


### PR DESCRIPTION
## Summary

- correct post-uplift truth wording in `proof_coverage.json` claims and public formal docs
- align README / PROOF_COVERAGE / RISK_MODEL with the actual 24-entry post-uplift registry reality
- normalize stale `LIVE+BRIDGE` status markers to canonical `proved` without changing theorem scope

## Formal Verification Checklist

> **Mandatory for any PR touching `.lean` files. Do not skip.**

### Invariant completeness

- [x] No `.lean` files changed — formal invariants unaffected

### Soundness

- [x] 0 `sorry` / `admit` in all changed files
- [x] 0 new `axiom`
- [x] All theorem statements match canonical spec semantics — no theorem scope changed
- [x] No `.lean` files changed — `lake env lean` check not applicable

### Proof quality

- [x] No proof quality regressions — only JSON status normalization and documentation updates

## Spec references

No spec sections changed. Changes are scoped to machine-readable registry metadata (`proof_coverage.json`) and public-facing narrative docs (README, PROOF_COVERAGE.md, RISK_MODEL.md).

## Test evidence

- `python3 tools/check_formal_registry_truth.py` — PASS
- `python3 -m unittest discover -s tests -v` — 142 tests PASS
- Count self-audit: 24 entries, 18 universal, 3 assumption-backed, 2 behavioral, 1 contract-level, 0 stated, 0 deferred — all match actual `proof_coverage.json`