### PR TITLE
formal: refresh spec section hash disposition

### DIFF
--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -4,7 +4,7 @@
   "claim_level": "refined",
   "spec_source_file": "spec/RUBIN_L1_CANONICAL.md",
   "spec_section_hashes_file": "spec/SECTION_HASHES.json",
-  "spec_section_hashes_sha3_256": "bfd9a8ed879b788b685fb9e8452e4c6cc3a409267d149ec68b35d8138e1c2f9a",
+  "spec_section_hashes_sha3_256": "bf3e0c11503096d44efb6f55732d88c96c46ccc51110d1e3bc3968d2f70e7671",
   "lean_toolchain_file": "rubin-formal/lean-toolchain",
   "refinement_bridge_file": "rubin-formal/refinement_bridge.json",
   "coverage": [


### PR DESCRIPTION
## Summary
- refresh `proof_coverage.json` `spec_section_hashes_sha3_256` after the latest `rubin-spec#232` thread-fix patch

## Why
`rubin-spec#232` changed `SECTION_HASHES.json` again while resolving live review feedback. `rubin-formal` must carry the same canonical SHA3-256 disposition to avoid spec/formal drift.

## Testing
- local registry truth check via pre-commit
- `lake build` via pre-push hook

## Links
- related spec PR: `rubin-spec#232`
- related task: `Q-SPEC-ROTATION-SEMANTIC-BINDING-SOURCE-01`