### PR TITLE
formal: lift block timestamp row to universal

### DIFF
--- a/RubinFormal/BlockTimestampBehavioral.lean
+++ b/RubinFormal/BlockTimestampBehavioral.lean
@@ -264,8 +264,9 @@ theorem validateBlockBasicCheck_timestamp_stage
                   | ok u' => simp [hTs, hNonce]
 
 /-- LIVE constrained acceptance on the real block-basic timestamp path:
-    once the prefix checks and nonce replay pass, `validateBlockBasicCheck`
-    accepts iff the derived MTP and timestamp satisfy the canonical bounds. -/
+    once the prefix checks and nonce replay pass, the derived MTP/timestamp
+    satisfying the canonical bounds is sufficient for
+    `validateBlockBasicCheck` to accept. -/
 theorem validateBlockBasicCheck_timestamp_ok_constrained
     (blockBytes : Bytes)
     (expectedPrevHash expectedTarget : Option Bytes)

--- a/RubinFormal/BlockTimestampBehavioral.lean
+++ b/RubinFormal/BlockTimestampBehavioral.lean
@@ -1,6 +1,8 @@
 import RubinFormal.BlockBasicCheckV1
+import RubinFormal.BytesEqLemmas
 namespace RubinFormal
 open BlockBasicCheckV1
+open BlockBasicV1
 
 -- ============================================================
 -- §16 block_timestamp_rules — Universal Upgrade
@@ -147,5 +149,227 @@ theorem timestampBounds_complete (mtp ts : Nat) :
   · exact Or.inl ⟨h, (timestampBounds_ok_iff mtp ts).mp h⟩
   · exact Or.inr (Or.inl ⟨h, (timestampBounds_old_iff mtp ts).mp h⟩)
   · exact Or.inr (Or.inr ⟨h, (timestampBounds_future_iff mtp ts).mp h⟩)
+
+private theorem except_unit_bind_pure_eq_self (x : Except String Unit) :
+    (match x with
+    | .error err => .error err
+    | .ok _ => .ok ()) = x := by
+  cases x <;> rfl
+
+-- ============================================================
+-- LIVE: validateBlockBasicCheck — timestamp stage on the top-level path
+-- ============================================================
+
+/-- Exact post-prefix decomposition of the real `validateBlockBasicCheck`
+    timestamp stage. Once parse/pow/target/linkage/merkle/witness checks
+    have passed on the live path, the remaining suffix is exactly:
+    derive `medianTimePast`, apply `timestampBounds`, then run nonce replay. -/
+theorem validateBlockBasicCheck_timestamp_stage
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (blockHeight : Nat)
+    (prevTimestamps : List Nat)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (hParse : BlockBasicV1.parseBlock blockBytes = .ok pb)
+    (hPow : BlockBasicV1.powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hWmr : BlockBasicV1.witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : BlockBasicV1.findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = BlockBasicV1.witnessCommitmentHash witnessRoot) :
+    validateBlockBasicCheck blockBytes expectedPrevHash expectedTarget blockHeight prevTimestamps =
+      (do
+        let mtp ← medianTimePast prevTimestamps
+        timestampBounds mtp pb.header.timestamp
+        nonceReplayCheck pb.txs) := by
+  have hCommitFalse : (gotCommit != BlockBasicV1.witnessCommitmentHash witnessRoot) = false := by
+    subst hEq
+    exact bytes_bne_self_false _
+  cases expectedTarget with
+  | none =>
+      cases expectedPrevHash with
+      | none =>
+          simp [validateBlockBasicCheck, enforceSigSuiteActivation, Bind.bind, Except.bind,
+            Pure.pure, Except.pure, hParse, hPow, hMerkle, hWmr, hCommit, hCommitFalse,
+            bytes_bne_self_false]
+          cases hMtp : medianTimePast prevTimestamps with
+          | error err => simp [hMtp, except_unit_bind_pure_eq_self]
+          | ok mtp =>
+              cases hTs : timestampBounds mtp pb.header.timestamp with
+              | error err => simp [hMtp, hTs, except_unit_bind_pure_eq_self]
+              | ok u =>
+                  cases hNonce : nonceReplayCheck pb.txs with
+                  | error err => simp [hTs, hNonce]
+                  | ok u' => simp [hTs, hNonce]
+      | some prev =>
+          simp at hPrev
+          have hPrevFalse : (pb.header.prevHash != prev) = false := by
+            subst hPrev
+            exact bytes_bne_self_false _
+          simp [validateBlockBasicCheck, enforceSigSuiteActivation, Bind.bind, Except.bind,
+            Pure.pure, Except.pure, hParse, hPow, hPrevFalse, hMerkle, hWmr, hCommit,
+            hCommitFalse, bytes_bne_self_false]
+          cases hMtp : medianTimePast prevTimestamps with
+          | error err => simp [hMtp, except_unit_bind_pure_eq_self]
+          | ok mtp =>
+              cases hTs : timestampBounds mtp pb.header.timestamp with
+              | error err => simp [hMtp, hTs, except_unit_bind_pure_eq_self]
+              | ok u =>
+                  cases hNonce : nonceReplayCheck pb.txs with
+                  | error err => simp [hTs, hNonce]
+                  | ok u' => simp [hTs, hNonce]
+  | some target =>
+      simp at hTarget
+      have hTargetFalse : (pb.header.target != target) = false := by
+        subst hTarget
+        exact bytes_bne_self_false _
+      cases expectedPrevHash with
+      | none =>
+          simp [validateBlockBasicCheck, enforceSigSuiteActivation, Bind.bind, Except.bind,
+            Pure.pure, Except.pure, hParse, hPow, hTargetFalse, hMerkle, hWmr, hCommit,
+            hCommitFalse, bytes_bne_self_false]
+          cases hMtp : medianTimePast prevTimestamps with
+          | error err => simp [hMtp, except_unit_bind_pure_eq_self]
+          | ok mtp =>
+              cases hTs : timestampBounds mtp pb.header.timestamp with
+              | error err => simp [hMtp, hTs, except_unit_bind_pure_eq_self]
+              | ok u =>
+                  cases hNonce : nonceReplayCheck pb.txs with
+                  | error err => simp [hTs, hNonce]
+                  | ok u' => simp [hTs, hNonce]
+      | some prev =>
+          simp at hPrev
+          have hPrevFalse : (pb.header.prevHash != prev) = false := by
+            subst hPrev
+            exact bytes_bne_self_false _
+          simp [validateBlockBasicCheck, enforceSigSuiteActivation, Bind.bind, Except.bind,
+            Pure.pure, Except.pure, hParse, hPow, hTargetFalse, hPrevFalse, hMerkle, hWmr,
+            hCommit, hCommitFalse, bytes_bne_self_false]
+          cases hMtp : medianTimePast prevTimestamps with
+          | error err => simp [hMtp, except_unit_bind_pure_eq_self]
+          | ok mtp =>
+              cases hTs : timestampBounds mtp pb.header.timestamp with
+              | error err => simp [hMtp, hTs, except_unit_bind_pure_eq_self]
+              | ok u =>
+                  cases hNonce : nonceReplayCheck pb.txs with
+                  | error err => simp [hTs, hNonce]
+                  | ok u' => simp [hTs, hNonce]
+
+/-- LIVE constrained acceptance on the real block-basic timestamp path:
+    once the prefix checks and nonce replay pass, `validateBlockBasicCheck`
+    accepts iff the derived MTP and timestamp satisfy the canonical bounds. -/
+theorem validateBlockBasicCheck_timestamp_ok_constrained
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (blockHeight : Nat)
+    (prevTimestamps : List Nat)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (mtp : Nat)
+    (hParse : BlockBasicV1.parseBlock blockBytes = .ok pb)
+    (hPow : BlockBasicV1.powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hWmr : BlockBasicV1.witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : BlockBasicV1.findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = BlockBasicV1.witnessCommitmentHash witnessRoot)
+    (hMtp : medianTimePast prevTimestamps = .ok mtp)
+    (hTs : mtp < pb.header.timestamp ∧ pb.header.timestamp ≤ mtp + MAX_FUTURE_DRIFT)
+    (hNonce : nonceReplayCheck pb.txs = .ok ()) :
+    validateBlockBasicCheck blockBytes expectedPrevHash expectedTarget blockHeight prevTimestamps =
+      .ok () := by
+  rw [validateBlockBasicCheck_timestamp_stage blockBytes expectedPrevHash expectedTarget
+    blockHeight prevTimestamps pb witnessRoot gotCommit hParse hPow hTarget hPrev hMerkle
+    hWmr hCommit hEq, hMtp]
+  have hTsOk : timestampBounds mtp pb.header.timestamp = .ok () :=
+    (timestampBounds_ok_iff mtp pb.header.timestamp).2 hTs
+  simp [hTsOk, hNonce, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+/-- LIVE constrained rejection on the real block-basic timestamp path:
+    after the same preceding live checks, a timestamp at-or-before the derived
+    median-time-past rejects with `BLOCK_ERR_TIMESTAMP_OLD`. -/
+theorem validateBlockBasicCheck_timestamp_old_rejected_constrained
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (blockHeight : Nat)
+    (prevTimestamps : List Nat)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (mtp : Nat)
+    (hParse : BlockBasicV1.parseBlock blockBytes = .ok pb)
+    (hPow : BlockBasicV1.powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hWmr : BlockBasicV1.witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : BlockBasicV1.findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = BlockBasicV1.witnessCommitmentHash witnessRoot)
+    (hMtp : medianTimePast prevTimestamps = .ok mtp)
+    (hOld : pb.header.timestamp ≤ mtp) :
+    validateBlockBasicCheck blockBytes expectedPrevHash expectedTarget blockHeight prevTimestamps =
+      .error "BLOCK_ERR_TIMESTAMP_OLD" := by
+  rw [validateBlockBasicCheck_timestamp_stage blockBytes expectedPrevHash expectedTarget
+    blockHeight prevTimestamps pb witnessRoot gotCommit hParse hPow hTarget hPrev hMerkle
+    hWmr hCommit hEq, hMtp]
+  have hTsOld : timestampBounds mtp pb.header.timestamp = .error "BLOCK_ERR_TIMESTAMP_OLD" :=
+    (timestampBounds_old_iff mtp pb.header.timestamp).2 hOld
+  simp [hTsOld, Bind.bind, Except.bind, Pure.pure, Except.pure]
+
+/-- LIVE constrained rejection on the real block-basic timestamp path:
+    after the same preceding live checks, a timestamp beyond the allowed future
+    drift rejects with `BLOCK_ERR_TIMESTAMP_FUTURE`. -/
+theorem validateBlockBasicCheck_timestamp_future_rejected_constrained
+    (blockBytes : Bytes)
+    (expectedPrevHash expectedTarget : Option Bytes)
+    (blockHeight : Nat)
+    (prevTimestamps : List Nat)
+    (pb : ParsedBlock)
+    (witnessRoot gotCommit : Bytes)
+    (mtp : Nat)
+    (hParse : BlockBasicV1.parseBlock blockBytes = .ok pb)
+    (hPow : BlockBasicV1.powCheck pb.header = .ok ())
+    (hTarget :
+      match expectedTarget with
+      | none => True
+      | some exp => pb.header.target = exp)
+    (hPrev :
+      match expectedPrevHash with
+      | none => True
+      | some exp => pb.header.prevHash = exp)
+    (hMerkle : BlockBasicV1.merkleRootTxids pb.txids = .ok pb.header.merkleRoot)
+    (hWmr : BlockBasicV1.witnessMerkleRootWtxids pb.wtxids = .ok witnessRoot)
+    (hCommit : BlockBasicV1.findCoinbaseAnchorCommitment pb.coinbaseTx = .ok gotCommit)
+    (hEq : gotCommit = BlockBasicV1.witnessCommitmentHash witnessRoot)
+    (hMtp : medianTimePast prevTimestamps = .ok mtp)
+    (hFuture : mtp < pb.header.timestamp ∧ mtp + MAX_FUTURE_DRIFT < pb.header.timestamp) :
+    validateBlockBasicCheck blockBytes expectedPrevHash expectedTarget blockHeight prevTimestamps =
+      .error "BLOCK_ERR_TIMESTAMP_FUTURE" := by
+  rw [validateBlockBasicCheck_timestamp_stage blockBytes expectedPrevHash expectedTarget
+    blockHeight prevTimestamps pb witnessRoot gotCommit hParse hPow hTarget hPrev hMerkle
+    hWmr hCommit hEq, hMtp]
+  have hTsFuture : timestampBounds mtp pb.header.timestamp = .error "BLOCK_ERR_TIMESTAMP_FUTURE" :=
+    (timestampBounds_future_iff mtp pb.header.timestamp).2 hFuture
+  simp [hTsFuture, Bind.bind, Except.bind, Pure.pure, Except.pure]
 
 end RubinFormal

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -1152,29 +1152,35 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_timestamp_vectors_pass",
+        "RubinFormal.medianTimePast_value",
+        "RubinFormal.medianTimePast_index_valid",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_ok_iff",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_old_iff",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_future_iff",
-        "RubinFormal.timestamp_after_mtp_accepted",
-        "RubinFormal.timestamp_at_mtp_rejected",
-        "RubinFormal.timestamp_before_mtp_rejected"
+        "RubinFormal.validateBlockBasicCheck_timestamp_stage",
+        "RubinFormal.validateBlockBasicCheck_timestamp_ok_constrained",
+        "RubinFormal.validateBlockBasicCheck_timestamp_old_rejected_constrained",
+        "RubinFormal.validateBlockBasicCheck_timestamp_future_rejected_constrained"
       ],
-      "file": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
+      "file": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
       "theorem_files": {
         "RubinFormal.Conformance.cv_timestamp_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVTimestampReplay.lean",
-        "RubinFormal.timestamp_after_mtp_accepted": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
-        "RubinFormal.timestamp_at_mtp_rejected": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
-        "RubinFormal.timestamp_before_mtp_rejected": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
+        "RubinFormal.medianTimePast_value": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
+        "RubinFormal.medianTimePast_index_valid": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_ok_iff": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
         "RubinFormal.BlockBasicCheckV1.timestampBounds_old_iff": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
-        "RubinFormal.BlockBasicCheckV1.timestampBounds_future_iff": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean"
+        "RubinFormal.BlockBasicCheckV1.timestampBounds_future_iff": "rubin-formal/RubinFormal/BlockBasicCheckV1.lean",
+        "RubinFormal.validateBlockBasicCheck_timestamp_stage": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
+        "RubinFormal.validateBlockBasicCheck_timestamp_ok_constrained": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
+        "RubinFormal.validateBlockBasicCheck_timestamp_old_rejected_constrained": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean",
+        "RubinFormal.validateBlockBasicCheck_timestamp_future_rejected_constrained": "rubin-formal/RubinFormal/BlockTimestampBehavioral.lean"
       },
-      "notes": "Mixed behavioral row with an explicit lane split: the theorem lane covers the old/future accept-reject boundary of `timestampBounds` once median-time-past has been supplied, while the fixture lane replays the current timestamp-bounds and block-basic timestamp vectors. Honest ceiling remains behavioral because the list-to-MTP extraction path is still evidenced by replay rather than a standalone theorem.",
+      "notes": "Universal theorem lane: `medianTimePast_value` plus `medianTimePast_index_valid` close the list-to-MTP extraction path on the live helper, `timestampBounds_*_iff` characterizes the canonical old/future/ok boundary, and the new constrained LIVE bridge theorems lift that boundary to the real `validateBlockBasicCheck` path once the parse/pow/target/linkage/merkle/witness prefix has passed. The top-level counted surface now includes exact acceptance and old/future rejection theorems on the live block-basic path rather than concrete regression wrappers. Separate fixture lane: CV-TIMESTAMP replay on shipped timestamp-bounds and block-basic vectors. That executable lane remains complementary evidence only and does not replace the universal theorem lane.",
       "limitations": [
-        "The universal theorem layer is over `timestampBounds` given an already-derived median-time-past value; the list-to-MTP extraction path remains evidenced by executable replay rather than a standalone theorem.",
+        "The counted LIVE bridge theorems are constrained to the real `validateBlockBasicCheck` path after parse/pow/target/linkage/merkle/witness prefix success, and the accept theorem additionally assumes nonce replay passes on the remaining suffix. This row does not claim unrelated block-basic stages beyond that covered timestamp gate.",
         "No chain-wide timestamp monotonicity claim beyond the covered `timestampBounds` gate and current replayed integration path is asserted here."
       ],
-      "evidence_level": "machine_checked_behavioral"
+      "evidence_level": "machine_checked_universal"
     },
     {
       "section_key": "fork_choice",


### PR DESCRIPTION
Fixes #463.

## Summary
- add constrained LIVE bridge theorems from `validateBlockBasicCheck` into the timestamp stage
- prove ok / old / future outcomes on the real top-level path under explicit pre-timestamp prefix assumptions
- lift `block_timestamp_rules` in `proof_coverage.json` from `machine_checked_behavioral` to `machine_checked_universal`

## Checks
- `~/.elan/bin/lake build`
- `python3 tools/check_formal_registry_truth.py`
- `python3 -m json.tool proof_coverage.json >/dev/null`
- `git diff --check`
- `bash tools/discipline-gate.sh --yes`
- `bash tools/self-audit-gate.sh --yes`
- `cl push` with local `codex exec` review (`summary-contract: PASS`)
