### PR TITLE
formal: split sighash digest residual

### DIFF
--- a/PROOF_COVERAGE.md
+++ b/PROOF_COVERAGE.md
@@ -4,7 +4,7 @@
 Машинный реестр: `rubin-formal/proof_coverage.json`
 
 Текущее состояние: machine-readable source-of-truth (`proof_coverage.json`) фиксирует
-`proof_level=refinement`, `claim_level=refined`, полный registry по 30 current coverage entries и явные
+`proof_level=refinement`, `claim_level=refined`, полный registry по 31 current coverage entries и явные
 `notes` / `limitations` для non-universal claims. Conformance-фикстуры
 `conformance/fixtures/CV-*.json` покрыты Lean replay/refinement слоем.
 
@@ -28,15 +28,15 @@
 
 Связка с hash-pinning:
 
-- `proof_coverage.json` сейчас содержит 30 machine-checked registry entries.
-- Все 30 текущих entries уже machine-checked; активных `stated` / `deferred` rows сейчас нет.
-- Не все 30 entries равны по силе claims: честная граница определяется `evidence_level` и `limitations`.
+- `proof_coverage.json` сейчас содержит 31 machine-checked registry entries.
+- Все 31 текущих entries уже machine-checked; активных `stated` / `deferred` rows сейчас нет.
+- Не все 31 entries равны по силе claims: честная граница определяется `evidence_level` и `limitations`.
 - Extra formal-only theorems (например, `CORE_EXT` tightening) не считаются pinned-section coverage,
   если они не внесены отдельной registry entry.
 
 ## Текущая раскладка evidence levels
 
-- `machine_checked_universal`: 24
+- `machine_checked_universal`: 25
 - `machine_checked_assumption_backed`: 4
 - `machine_checked_behavioral`: 2
 - `machine_checked_contract`: 0

--- a/RISK_MODEL.md
+++ b/RISK_MODEL.md
@@ -69,7 +69,7 @@
 
 На текущем refinement-срезе registry содержит:
 
-- `24` universal entries;
+- `25` universal entries;
 - `4` assumption-backed entries;
 - `2` behavioral entries;
 - `0` contract-level entries;

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -284,6 +284,7 @@
       "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_sighash_vectors_pass",
+        "RubinFormal.sighash_v1_proved",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective",
         "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs",
         "RubinFormal.SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input",
@@ -308,6 +309,7 @@
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.Conformance.cv_sighash_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
+        "RubinFormal.sighash_v1_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input": "rubin-formal/RubinFormal/SighashV1.lean",

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -281,7 +281,7 @@
     {
       "section_key": "sighash_v1",
       "section_heading": "## 12. Sighash v1 (Normative)",
-      "status": "proved_with_axiom",
+      "status": "proved",
       "theorems": [
         "RubinFormal.Conformance.cv_sighash_vectors_pass",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective",
@@ -303,11 +303,11 @@
         "RubinFormal.validateTxContextSighashWitness_ok_iff",
         "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects",
         "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects",
-        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects",
-        "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision"
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects"
       ],
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
+        "RubinFormal.Conformance.cv_sighash_vectors_pass": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
         "RubinFormal.SighashV1.buildPreimageFrameParts_injective": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.selectHashPrevouts_all_commits_all_inputs": "rubin-formal/RubinFormal/SighashV1.lean",
         "RubinFormal.SighashV1.selectHashPrevouts_anyonecanpay_commits_current_input": "rubin-formal/RubinFormal/SighashV1.lean",
@@ -327,15 +327,30 @@
         "RubinFormal.validateTxContextSighashWitness_ok_iff": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
         "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
         "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
-        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean"
+      },
+      "notes": "Universal theorem lane: `sighash_v1_proved` keeps the structural selection/preimage-frame surface explicit, while the live TXCTX `allowed_sighash_set` gate/witness theorems register the runtime accept/reject boundary for valid, invalid-base, empty-signature, and disallowed-type paths. Separate fixture lane: CV-SIGHASH replay for the shipped digest vectors. That executable lane is complementary evidence only and does not replace the universal theorem lane. The SHA3 digest-collision ceiling is tracked separately in `sighash_v1_digest_collision_residual` rather than depressing this live selection/TXCTX row.",
+      "limitations": [
+        "The executable digestV1 replay path still covers the current fixture subset and is not a universal tx-level equivalence proof for arbitrary raw transaction pairs.",
+        "The collision-resistance ceiling for equal live `digestV1` outputs on distinct executable preimages is not claimed in this row and is tracked separately in `sighash_v1_digest_collision_residual`."
+      ],
+      "evidence_level": "machine_checked_universal"
+    },
+    {
+      "section_key": "sighash_v1_digest_collision_residual",
+      "section_heading": "## Sighash v1 Digest Collision Residual",
+      "status": "proved_with_axiom",
+      "theorems": [
+        "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision"
+      ],
+      "file": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+      "theorem_files": {
         "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean"
       },
-      "notes": "Assumption-backed theorem lane: live selection theorems, the live TXCTX `allowed_sighash_set` gate/witness bridge, and an explicit reduction theorem showing that equal live `digestV1` outputs on distinct executable preimages imply a SHA3-256 collision obligation. Separate fixture lane: CV-SIGHASH replay for the shipped digest vectors. That executable lane is complementary evidence only and does not replace the assumption-backed theorem lane. This remains the honest ceiling for §12 without overclaiming arbitrary raw-tx equivalence.",
+      "notes": "Dedicated assumption-backed residual for the live `digestV1` crypto ceiling. The counted reduction theorem shows that when two live `digestV1` executions succeed with equal outputs and their executable preimages are distinct, SHA3-256 would have to collide on those distinct preimages. This row intentionally carries only that residual and does not re-count the structural selector/TXCTX gate surface already owned by the universal `sighash_v1` row.",
       "limitations": [
-        "The executable digestV1 replay path still covers the current fixture subset and is not yet a universal tx-level equivalence proof for every §12 sighash_type branch or invalid-type rejection path.",
-        "The digest theorem is a reduction theorem: when two live digestV1 executions succeed with equal outputs and their executable preimages are distinct, SHA3-256 would have to collide. The proof does not itself claim cryptographic impossibility.",
-        "No universal proof is claimed here for deriving preimage distinctness from arbitrary raw transaction pairs, DaCoreFieldsBytes variation, or every witness-carried sighash_type path.",
-        "The TXCTX allowlist bridge now covers the live `validateTxContextSighashGate` / `validateTxContextSighashWitness` surface, but broader raw-tx/hash equivalence residuals remain out of scope."
+        "This is a reduction theorem, not an axiom-free impossibility proof: ruling out equal digests on distinct executable preimages still depends on SHA3-256 collision resistance.",
+        "The row does not claim arbitrary raw-tx preimage distinctness or a universal proof for every possible witness-carried transaction variation outside the executable digest surface named in the theorem."
       ],
       "evidence_level": "machine_checked_assumption_backed"
     },
@@ -1654,9 +1669,9 @@
   "proof_level": "refinement",
   "claims": {
     "allowed": [
-      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; the registry now records 30 machine-checked coverage entries, but this is still not a universal proof of full CANONICAL semantics",
+      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; the registry now records 31 machine-checked coverage entries, but this is still not a universal proof of full CANONICAL semantics",
       "Executable Lean↔Go/Rust bridge evidence is op-scoped and mixed: depending on the critical op, the honest ceiling recorded in rubin-formal/refinement_bridge.json is universal, assumption-backed, behavioral, or contract-level rather than one uniform Go-trace refinement claim over the full conformance set",
-      "The registry currently covers 30 machine-checked coverage entries. Each entry carries an explicit evidence_level distinguishing universal proofs, behavioral proofs, assumption-backed proofs, and contract-level fixture coverage.",
+      "The registry currently covers 31 machine-checked coverage entries. Each entry carries an explicit evidence_level distinguishing universal proofs, behavioral proofs, assumption-backed proofs, and contract-level fixture coverage.",
       "formal claims are bounded by explicit forbidden claims below",
       "Bridge theorems (LIVE/BRIDGE class) prove properties of Lean transcriptions of Go/Rust functions. Lean-to-Go/Rust parity is verified by human code review, not machine-checked. The behavioral claim applies to the Lean transcription; transfer to Go/Rust binary relies on the reviewed parity."
     ],

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -19,8 +19,8 @@
     {
       "op": "sighash_v1",
       "gate": "CV-SIGHASH",
-      "model_theorem": "RubinFormal.Conformance.cv_sighash_vectors_pass",
-      "lean_file": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
+      "model_theorem": "RubinFormal.sighash_v1_proved",
+      "lean_file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_file": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
       "evidence_level": "machine_checked_universal",
       "spec_section": "§12",
@@ -54,7 +54,7 @@
         "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects",
         "RubinFormal.validateTxContextSighashWitness_disallowed_rejects"
       ],
-      "notes": "Bridge upgraded from contract to universal for the live selector/TXCTX gate surface because the assumption-backed digest-collision reduction theorem is no longer counted here. The row remains honest about residual raw-tx/preimage distinctness gaps and does not overclaim universal tx-level digest equivalence."
+      "notes": "Universal bridge for the live selector/TXCTX gate surface after splitting the assumption-backed digest-collision theorem into its own residual row. This row remains honest about residual raw-tx/preimage distinctness gaps and does not overclaim universal tx-level digest equivalence."
     },
     {
       "op": "sighash_v1_digest_collision_residual",

--- a/refinement_bridge.json
+++ b/refinement_bridge.json
@@ -22,14 +22,13 @@
       "model_theorem": "RubinFormal.Conformance.cv_sighash_vectors_pass",
       "lean_file": "rubin-formal/RubinFormal/Conformance/CVSighashReplay.lean",
       "theorem_file": "rubin-formal/RubinFormal/SighashRefinementUpgrade.lean",
-      "evidence_level": "machine_checked_assumption_backed",
+      "evidence_level": "machine_checked_universal",
       "spec_section": "§12",
       "go_function": "DigestV1",
-      "contract_scope": "CV-SIGHASH replay plus substantive live sighash-selection rejection theorems on selectHashPrevouts/selectHashSequences/selectHashOutputs, live TXCTX allowed_sighash_set bridge theorems on validateTxContextSighashGate/validateTxContextSighashWitness, and an explicit reduction theorem showing that equal live digestV1 outputs on distinct executable preimages would require a SHA3-256 collision.",
+      "contract_scope": "CV-SIGHASH replay plus substantive live sighash-selection theorems on selectHashPrevouts/selectHashSequences/selectHashOutputs and live TXCTX allowed_sighash_set bridge theorems on validateTxContextSighashGate/validateTxContextSighashWitness. This row covers the structural selector/TXCTX gate surface only; the digest collision ceiling is tracked separately.",
       "limitations": [
-        "This remains a contract-level bridge: the executable replay covers the current CV-SIGHASH fixture set, not every possible raw transaction / witness-carried sighash_type combination.",
-        "The digest reduction theorem is assumption-backed: it turns equal live digests plus distinct executable preimages into a SHA3-256 collision obligation, but it does not itself prove such collisions impossible.",
-        "No universal proof is claimed here for deriving preimage distinctness from arbitrary raw transaction pairs, DaCoreFieldsBytes variation, or every witness-carried sighash_type combination."
+        "The executable replay covers the current CV-SIGHASH fixture set and remains complementary evidence, not a universal proof for arbitrary raw transaction / witness-carried sighash_type combinations outside the named theorem surface.",
+        "This row does not claim the SHA3 collision-resistance ceiling for equal live digestV1 outputs on distinct executable preimages; that residual is tracked separately in `sighash_v1_digest_collision_residual`."
       ],
       "supporting_theorems": [
         "RubinFormal.sighash_v1_proved",
@@ -53,10 +52,28 @@
         "RubinFormal.validateTxContextSighashWitness_ok_iff",
         "RubinFormal.validateTxContextSighashWitness_empty_signature_rejects",
         "RubinFormal.validateTxContextSighashWitness_invalid_base_rejects",
-        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects",
+        "RubinFormal.validateTxContextSighashWitness_disallowed_rejects"
+      ],
+      "notes": "Bridge upgraded from contract to universal for the live selector/TXCTX gate surface because the assumption-backed digest-collision reduction theorem is no longer counted here. The row remains honest about residual raw-tx/preimage distinctness gaps and does not overclaim universal tx-level digest equivalence."
+    },
+    {
+      "op": "sighash_v1_digest_collision_residual",
+      "gate": "CV-SIGHASH",
+      "model_theorem": "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision",
+      "lean_file": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+      "theorem_file": "rubin-formal/RubinFormal/SighashAssumptionBridge.lean",
+      "evidence_level": "machine_checked_assumption_backed",
+      "spec_section": "§12",
+      "go_function": "DigestV1",
+      "contract_scope": "Explicit reduction theorem for the remaining live digestV1 crypto ceiling: equal live digestV1 outputs on distinct executable preimages would require a SHA3-256 collision.",
+      "limitations": [
+        "This row is intentionally residual only. It does not re-count the structural selector/TXCTX allowlist gate surface already carried by `sighash_v1`.",
+        "The theorem is a reduction theorem, not an axiom-free impossibility proof: ruling out equal digests on distinct executable preimages still depends on SHA3-256 collision resistance."
+      ],
+      "supporting_theorems": [
         "RubinFormal.digestV1_output_collision_reduces_to_sha3_collision"
       ],
-      "notes": "Bridge upgraded from contract to assumption-backed because the section now includes both the live TXCTX allowlist surface and an explicit digest-collision reduction theorem. The result is still honest about residual raw-tx/preimage distinctness gaps and does not overclaim universal tx-level digest equivalence."
+      "notes": "Dedicated assumption-backed residual for the live digestV1 crypto boundary after the universal split of the selector/TXCTX gate lane."
     },
     {
       "op": "retarget_v1",


### PR DESCRIPTION
Fixes #466

## Summary
- split `sighash_v1` into a universal selector/TXCTX lane and a separate assumption-backed digest-collision residual
- sync `refinement_bridge.json` with the same split so shared-op evidence levels stay honest
- update public counts/docs to 31 rows / 25 universal / 4 assumption-backed / 2 behavioral

## Verification
- `python3 -m json.tool proof_coverage.json >/dev/null`
- `python3 -m json.tool refinement_bridge.json >/dev/null`
- `python3 tools/check_formal_registry_truth.py`
- `~/.elan/bin/lake build`
- `git diff --check`
- `bash tools/discipline-gate.sh --yes`
- `bash tools/self-audit-gate.sh --yes`
- sanctioned `cl push` local `codex exec` review: PASS