### PR TITLE
formal: split consensus constants residual

### DIFF
--- a/PROOF_COVERAGE.md
+++ b/PROOF_COVERAGE.md
@@ -4,7 +4,7 @@
 Машинный реестр: `rubin-formal/proof_coverage.json`
 
 Текущее состояние: machine-readable source-of-truth (`proof_coverage.json`) фиксирует
-`proof_level=refinement`, `claim_level=refined`, полный registry по 31 current coverage entries и явные
+`proof_level=refinement`, `claim_level=refined`, полный registry по 32 current coverage entries и явные
 `notes` / `limitations` для non-universal claims. Conformance-фикстуры
 `conformance/fixtures/CV-*.json` покрыты Lean replay/refinement слоем.
 
@@ -28,15 +28,15 @@
 
 Связка с hash-pinning:
 
-- `proof_coverage.json` сейчас содержит 31 machine-checked registry entries.
-- Все 31 текущих entries уже machine-checked; активных `stated` / `deferred` rows сейчас нет.
-- Не все 31 entries равны по силе claims: честная граница определяется `evidence_level` и `limitations`.
+- `proof_coverage.json` сейчас содержит 32 machine-checked registry entries.
+- Все 32 текущих entries уже machine-checked; активных `stated` / `deferred` rows сейчас нет.
+- Не все 32 entries равны по силе claims: честная граница определяется `evidence_level` и `limitations`.
 - Extra formal-only theorems (например, `CORE_EXT` tightening) не считаются pinned-section coverage,
   если они не внесены отдельной registry entry.
 
 ## Текущая раскладка evidence levels
 
-- `machine_checked_universal`: 25
+- `machine_checked_universal`: 26
 - `machine_checked_assumption_backed`: 4
 - `machine_checked_behavioral`: 2
 - `machine_checked_contract`: 0

--- a/RISK_MODEL.md
+++ b/RISK_MODEL.md
@@ -69,7 +69,7 @@
 
 На текущем refinement-срезе registry содержит:
 
-- `25` universal entries;
+- `26` universal entries;
 - `4` assumption-backed entries;
 - `2` behavioral entries;
 - `0` contract-level entries;

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -42,7 +42,7 @@
         "RubinFormal.witness_sentinel_valid_accepts",
         "RubinFormal.witness_validation_exhaustive"
       ],
-      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "file": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
       "theorem_files": {
         "RubinFormal.sem001_mldsa_bounded_lengths_proved": "rubin-formal/RubinFormal/FormalGap03.lean",
         "RubinFormal.validateWitnessItemLengths_eq_explicit": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -13,9 +13,27 @@
       "section_heading": "## 4. Consensus Constants (Wire-Level)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.sem001_mldsa_bounded_lengths_proved",
         "RubinFormal.subsidy_u128_safety_proved",
-        "RubinFormal.htlc_timelock_proved",
+        "RubinFormal.htlc_timelock_proved"
+      ],
+      "file": "rubin-formal/RubinFormal/PinnedSections.lean",
+      "theorem_files": {
+        "RubinFormal.subsidy_u128_safety_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
+        "RubinFormal.htlc_timelock_proved": "rubin-formal/RubinFormal/PinnedSections.lean"
+      },
+      "notes": "Universal finite-constant lane for the dedicated Section 4 constant theorems. `subsidy_u128_safety_proved` closes the §19.1 subsidy arithmetic safety ceiling, and `htlc_timelock_proved` closes the strict refund-before-expiry timelock semantics. This split intentionally stops short of the live witness-length validator surface; that pre-rotation `validateWitnessItemLengths` subset now lives in its own behavioral residual row rather than depressing the dedicated constant lane.",
+      "limitations": [
+        "This row does not claim the legacy/pre-rotation `validateWitnessItemLengths` branch surface. That live witness-length subset is tracked separately in `consensus_constants_witness_lengths_pre_rotation`.",
+        "Other Section 4 literals that already belong to dedicated rows such as weight accounting or DA integrity remain outside this finite-constant lane and are not re-counted here."
+      ],
+      "evidence_level": "machine_checked_universal"
+    },
+    {
+      "section_key": "consensus_constants_witness_lengths_pre_rotation",
+      "section_heading": "## 4. Consensus Constants (Witness-Length Pre-Rotation Residual)",
+      "status": "proved",
+      "theorems": [
+        "RubinFormal.sem001_mldsa_bounded_lengths_proved",
         "RubinFormal.validateWitnessItemLengths_eq_explicit",
         "RubinFormal.witness_mldsa_bounds_violated_rejects",
         "RubinFormal.witness_mldsa_bounds_satisfied_accepts",
@@ -27,8 +45,6 @@
       "file": "rubin-formal/RubinFormal/PinnedSections.lean",
       "theorem_files": {
         "RubinFormal.sem001_mldsa_bounded_lengths_proved": "rubin-formal/RubinFormal/FormalGap03.lean",
-        "RubinFormal.subsidy_u128_safety_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
-        "RubinFormal.htlc_timelock_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.validateWitnessItemLengths_eq_explicit": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
         "RubinFormal.witness_mldsa_bounds_violated_rejects": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
         "RubinFormal.witness_mldsa_bounds_satisfied_accepts": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
@@ -37,9 +53,9 @@
         "RubinFormal.witness_sentinel_valid_accepts": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
         "RubinFormal.witness_validation_exhaustive": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean"
       },
-      "notes": "Behavioral ceiling for the finite Section 4 witness-length subset. The counted LIVE theorems in ConsensusConstantsBehavioral still close only the default pre-rotation `validateWitnessItemLengths` branch surface: ML-DSA-87 bound rejection/acceptance, unknown-suite rejection, sentinel rejection/acceptance, and the constrained outcome partition for that live validator. Dedicated pinned theorem entries separately cover subsidy U128 safety and HTLC timelock semantics. This row does not uplift the newer registry-aware parser model in `TxParseV2.parseWitnessItemWithRegistry`, nor does it claim post-rotation registered-suite witness canonicalization parity. Other Section 4 constants intentionally remain owned by their own dedicated rows such as weight accounting and DA integrity rather than being overclaimed here as a single section-wide universal theorem.",
+      "notes": "Behavioral residual row for the Section 4 witness-length subset. `sem001_mldsa_bounded_lengths_proved` packages the ML-DSA-87 iff boundary under its explicit suite hypothesis, while the counted LIVE theorems in ConsensusConstantsBehavioral still close only the default pre-rotation `validateWitnessItemLengths` branch surface: ML-DSA-87 bound rejection/acceptance, unknown-suite rejection, sentinel rejection/acceptance, and the constrained outcome partition for that live validator. This row does not uplift the newer registry-aware parser model in `TxParseV2.parseWitnessItemWithRegistry`, nor does it claim post-rotation registered-suite witness canonicalization parity.",
       "limitations": [
-        "Finite pinned constants are not a meaningful section-wide universal target here. This row aggregates the pre-rotation live `validateWitnessItemLengths` subset plus dedicated subsidy/HTLC constant theorems, while other Section 4 literals remain claimed by their own dedicated rows.",
+        "This residual row intentionally covers only the legacy/pre-rotation `validateWitnessItemLengths` subset plus the explicit ML-DSA-87 iff theorem. It does not re-count the dedicated finite constants now carried by the universal `consensus_constants` row.",
         "Registry-aware parse-stage witness classification and registered-suite canonicalization are intentionally not counted by this row and are not yet claimed here as covered by the Section 4 witness-length subset."
       ],
       "evidence_level": "machine_checked_behavioral"
@@ -1671,9 +1687,9 @@
   "proof_level": "refinement",
   "claims": {
     "allowed": [
-      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; the registry now records 31 machine-checked coverage entries, but this is still not a universal proof of full CANONICAL semantics",
+      "Lean executable semantics replay all conformance fixtures (CV-*.json) with byte-level input coverage; the registry now records 32 machine-checked coverage entries, but this is still not a universal proof of full CANONICAL semantics",
       "Executable Lean↔Go/Rust bridge evidence is op-scoped and mixed: depending on the critical op, the honest ceiling recorded in rubin-formal/refinement_bridge.json is universal, assumption-backed, behavioral, or contract-level rather than one uniform Go-trace refinement claim over the full conformance set",
-      "The registry currently covers 31 machine-checked coverage entries. Each entry carries an explicit evidence_level distinguishing universal proofs, behavioral proofs, assumption-backed proofs, and contract-level fixture coverage.",
+      "The registry currently covers 32 machine-checked coverage entries. Each entry carries an explicit evidence_level distinguishing universal proofs, behavioral proofs, assumption-backed proofs, and contract-level fixture coverage.",
       "formal claims are bounded by explicit forbidden claims below",
       "Bridge theorems (LIVE/BRIDGE class) prove properties of Lean transcriptions of Go/Rust functions. Lean-to-Go/Rust parity is verified by human code review, not machine-checked. The behavioral claim applies to the Lean transcription; transfer to Go/Rust binary relies on the reviewed parity."
     ],


### PR DESCRIPTION
Fixes #471

## Scope
- split `consensus_constants` into a universal finite-constant lane and a behavioral witness-length residual
- keep the pre-rotation `validateWitnessItemLengths` subset below universal
- sync coverage/docs counts with the split

## Verification
- `python3 -m json.tool proof_coverage.json >/dev/null`
- `python3 tools/check_formal_registry_truth.py`
- `~/.elan/bin/lake build`
- `git diff --check`
- `bash tools/discipline-gate.sh --yes`
- `bash tools/self-audit-gate.sh --yes`
- sanctioned `cl push` with local `codex exec` review (`PASS`)
