### PR TITLE
formal: uplift witness-length pre-rotation registry fragment

### DIFF
--- a/PROOF_COVERAGE.md
+++ b/PROOF_COVERAGE.md
@@ -36,9 +36,9 @@
 
 ## Текущая раскладка evidence levels
 
-- `machine_checked_universal`: 28
+- `machine_checked_universal`: 29
 - `machine_checked_assumption_backed`: 4
-- `machine_checked_behavioral`: 2
+- `machine_checked_behavioral`: 1
 - `machine_checked_contract`: 0
 
 ## Lean ↔ Go/Rust bridge ceiling

--- a/RISK_MODEL.md
+++ b/RISK_MODEL.md
@@ -69,9 +69,9 @@
 
 На текущем refinement-срезе registry содержит:
 
-- `28` universal entries;
+- `29` universal entries;
 - `4` assumption-backed entries;
-- `2` behavioral entries;
+- `1` behavioral entry;
 - `0` contract-level entries;
 - `0` stated rows;
 - `0` deferred rows.

--- a/RubinFormal/StructuralRulesBehavioral.lean
+++ b/RubinFormal/StructuralRulesBehavioral.lean
@@ -1,5 +1,7 @@
-import RubinFormal.UtxoApplyGenesisV1
 import RubinFormal.BytesEqLemmas
+import RubinFormal.ConsensusConstantsBehavioral
+import RubinFormal.FormalGap03
+import RubinFormal.UtxoApplyGenesisV1
 
 /-!
 # Transaction Structural Rules Behavioral Proofs (§16)
@@ -720,6 +722,22 @@ theorem vault_threshold_required_count_accepts_pre_rotation
 
 /-! ### R1-R6 Witness item lengths — registry companions -/
 
+/-- **R0 registry companion:** the ML-DSA-87 iff boundary transfers to the
+    authoritative pre-rotation registry-aware witness validator on
+    `PRE_ROTATION_REGISTRY`. BRIDGE via
+    `validateWitnessItemLengths_eq_registry_pre_rotation`. -/
+theorem sem001_mldsa_bounded_lengths_registry_pre_rotation :
+    ∀ (w : WitnessItem) (blockHeight : Nat),
+      w.suiteId = UtxoApplyGenesisV1.SUITE_ID_ML_DSA_87 →
+      (UtxoApplyGenesisV1.validateWitnessItemLengthsRegistry
+          Rotation.PRE_ROTATION_REGISTRY w blockHeight = .ok () ↔
+          w.pubkey.size = UtxoApplyGenesisV1.ML_DSA_87_PUBKEY_BYTES ∧
+          0 < w.signature.size ∧
+          w.signature.size ≤ UtxoApplyGenesisV1.ML_DSA_87_SIG_BYTES + 1) := by
+  intro w blockHeight hSuite
+  rw [← UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation]
+  exact sem001_mldsa_bounded_lengths_proved w blockHeight hSuite
+
 /-- **R1 registry companion:** Any suite ID ∉ {SENTINEL, ML_DSA_87} is
     rejected by `validateWitnessItemLengthsRegistry PRE_ROTATION_REGISTRY`
     with TX_ERR_SIG_ALG_INVALID. BRIDGE to `unknown_suite_rejected_pre_rotation`
@@ -810,6 +828,22 @@ theorem mldsa87_valid_accepted_registry_pre_rotation
       .ok () := by
   rw [← UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation]
   exact mldsa87_valid_accepted_pre_rotation w h hM hPOk hSPos hSBound
+
+/-- **R6b registry companion:** exhaustive constrained outcome partition for
+    the authoritative pre-rotation registry-aware witness validator.
+    BRIDGE via `validateWitnessItemLengths_eq_registry_pre_rotation`. -/
+theorem witness_validation_exhaustive_registry_pre_rotation
+    (w : WitnessItem) (h : Nat) :
+    UtxoApplyGenesisV1.validateWitnessItemLengthsRegistry
+        Rotation.PRE_ROTATION_REGISTRY w h = .error "TX_ERR_PARSE" ∨
+      UtxoApplyGenesisV1.validateWitnessItemLengthsRegistry
+        Rotation.PRE_ROTATION_REGISTRY w h = .error "TX_ERR_SIG_NONCANONICAL" ∨
+      UtxoApplyGenesisV1.validateWitnessItemLengthsRegistry
+        Rotation.PRE_ROTATION_REGISTRY w h = .error "TX_ERR_SIG_ALG_INVALID" ∨
+      UtxoApplyGenesisV1.validateWitnessItemLengthsRegistry
+        Rotation.PRE_ROTATION_REGISTRY w h = .ok () := by
+  rw [← UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation]
+  exact witness_validation_exhaustive w h
 
 /-! ### R7-R11 Threshold sig spend — registry companions -/
 

--- a/RubinFormal/StructuralRulesBehavioral.lean
+++ b/RubinFormal/StructuralRulesBehavioral.lean
@@ -720,7 +720,7 @@ theorem vault_threshold_required_count_accepts_pre_rotation
     rotation registries with additional suites are not covered — that's
     Wave A4+/F scope. -/
 
-/-! ### R1-R6 Witness item lengths — registry companions -/
+/-! ### R0-R6b Witness item lengths — registry companions -/
 
 /-- **R0 registry companion:** the ML-DSA-87 iff boundary transfers to the
     authoritative pre-rotation registry-aware witness validator on

--- a/proof_coverage.json
+++ b/proof_coverage.json
@@ -21,7 +21,7 @@
         "RubinFormal.subsidy_u128_safety_proved": "rubin-formal/RubinFormal/PinnedSections.lean",
         "RubinFormal.htlc_timelock_proved": "rubin-formal/RubinFormal/PinnedSections.lean"
       },
-      "notes": "Universal finite-constant lane for the dedicated Section 4 constant theorems. `subsidy_u128_safety_proved` closes the §19.1 subsidy arithmetic safety ceiling, and `htlc_timelock_proved` closes the strict refund-before-expiry timelock semantics. This split intentionally stops short of the live witness-length validator surface and the Section 4 native binding-manifest fragment. Those two surfaces now live in dedicated behavioral residual rows rather than depressing the dedicated constant lane.",
+      "notes": "Universal finite-constant lane for the dedicated Section 4 constant theorems. `subsidy_u128_safety_proved` closes the §19.1 subsidy arithmetic safety ceiling, and `htlc_timelock_proved` closes the strict refund-before-expiry timelock semantics. This split intentionally stops short of the live witness-length validator surface and the Section 4 native binding-manifest fragment. Those two surfaces now live in dedicated scoped rows rather than depressing the dedicated constant lane.",
       "limitations": [
         "This row does not claim the legacy/pre-rotation `validateWitnessItemLengths` branch surface. That live witness-length subset is tracked separately in `consensus_constants_witness_lengths_pre_rotation`.",
         "Other Section 4 literals that already belong to dedicated rows such as weight accounting or DA integrity remain outside this finite-constant lane and are not re-counted here.",
@@ -31,35 +31,40 @@
     },
     {
       "section_key": "consensus_constants_witness_lengths_pre_rotation",
-      "section_heading": "## 4. Consensus Constants (Witness-Length Pre-Rotation Residual)",
+      "section_heading": "## 4. Consensus Constants (Witness-Length Pre-Rotation Registry Fragment)",
       "status": "proved",
       "theorems": [
-        "RubinFormal.sem001_mldsa_bounded_lengths_proved",
-        "RubinFormal.validateWitnessItemLengths_eq_explicit",
-        "RubinFormal.witness_mldsa_bounds_violated_rejects",
-        "RubinFormal.witness_mldsa_bounds_satisfied_accepts",
-        "RubinFormal.witness_unknown_suite_rejects",
-        "RubinFormal.witness_sentinel_nonempty_rejects",
-        "RubinFormal.witness_sentinel_valid_accepts",
-        "RubinFormal.witness_validation_exhaustive"
+        "RubinFormal.UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation",
+        "RubinFormal.sem001_mldsa_bounded_lengths_registry_pre_rotation",
+        "RubinFormal.unknown_suite_rejected_registry_pre_rotation",
+        "RubinFormal.sentinel_nonempty_rejected_registry_pre_rotation",
+        "RubinFormal.sentinel_empty_accepted_registry_pre_rotation",
+        "RubinFormal.mldsa87_wrong_pubkey_rejected_registry_pre_rotation",
+        "RubinFormal.mldsa87_empty_sig_rejected_registry_pre_rotation",
+        "RubinFormal.mldsa87_sig_too_large_rejected_registry_pre_rotation",
+        "RubinFormal.mldsa87_valid_accepted_registry_pre_rotation",
+        "RubinFormal.witness_validation_exhaustive_registry_pre_rotation"
       ],
-      "file": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
+      "file": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
       "theorem_files": {
-        "RubinFormal.sem001_mldsa_bounded_lengths_proved": "rubin-formal/RubinFormal/FormalGap03.lean",
-        "RubinFormal.validateWitnessItemLengths_eq_explicit": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_mldsa_bounds_violated_rejects": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_mldsa_bounds_satisfied_accepts": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_unknown_suite_rejects": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_sentinel_nonempty_rejects": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_sentinel_valid_accepts": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean",
-        "RubinFormal.witness_validation_exhaustive": "rubin-formal/RubinFormal/ConsensusConstantsBehavioral.lean"
+        "RubinFormal.UtxoApplyGenesisV1.validateWitnessItemLengths_eq_registry_pre_rotation": "rubin-formal/RubinFormal/UtxoApplyGenesisV1.lean",
+        "RubinFormal.sem001_mldsa_bounded_lengths_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.unknown_suite_rejected_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.sentinel_nonempty_rejected_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.sentinel_empty_accepted_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.mldsa87_wrong_pubkey_rejected_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.mldsa87_empty_sig_rejected_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.mldsa87_sig_too_large_rejected_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.mldsa87_valid_accepted_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean",
+        "RubinFormal.witness_validation_exhaustive_registry_pre_rotation": "rubin-formal/RubinFormal/StructuralRulesBehavioral.lean"
       },
-      "notes": "Behavioral residual row for the Section 4 witness-length subset. `sem001_mldsa_bounded_lengths_proved` packages the ML-DSA-87 iff boundary under its explicit suite hypothesis, while the counted LIVE theorems in ConsensusConstantsBehavioral still close only the default pre-rotation `validateWitnessItemLengths` branch surface: ML-DSA-87 bound rejection/acceptance, unknown-suite rejection, sentinel rejection/acceptance, and the constrained outcome partition for that live validator. This row does not uplift the newer registry-aware parser model in `TxParseV2.parseWitnessItemWithRegistry` and does not claim post-rotation registered-suite witness canonicalization parity.",
+      "notes": "Universal row for the authoritative pre-rotation witness-length fragment. `validateWitnessItemLengths_eq_registry_pre_rotation` closes the full bridge from the legacy hardcoded validator to `validateWitnessItemLengthsRegistry PRE_ROTATION_REGISTRY`; `sem001_mldsa_bounded_lengths_registry_pre_rotation` lifts the ML-DSA-87 iff boundary onto that authoritative registry-aware live path; the counted registry companion theorems close unknown-suite rejection, sentinel rejection/acceptance, the three ML-DSA-87 rejection paths, valid acceptance, and the constrained outcome partition on the same live validator. This upgrades the Section 4 witness-length subset from the legacy helper-bound surface to the authoritative pre-rotation registry-aware witness validator without claiming arbitrary post-rotation registry semantics or parse-stage canonicalization.",
       "limitations": [
-        "This residual row intentionally covers only the legacy/pre-rotation `validateWitnessItemLengths` subset plus the explicit ML-DSA-87 iff theorem. It does not re-count the dedicated finite constants now carried by the universal `consensus_constants` row.",
-        "Registry-aware parse-stage witness classification and registered-suite canonicalization are intentionally not counted by this row and are not yet claimed here as covered by the Section 4 witness-length subset."
+        "Scope is `validateWitnessItemLengthsRegistry Rotation.PRE_ROTATION_REGISTRY` only. This row does not claim arbitrary post-rotation registries, additional native suites, or release-time registry drift handling beyond the singleton pre-rotation registry.",
+        "Registry-aware parse-stage witness classification and registered-suite canonicalization in `TxParseV2.parseWitnessItemWithRegistry` are still intentionally out of scope for this Section 4 witness-length fragment.",
+        "This row does not re-count the dedicated finite constants carried by `consensus_constants` or the Section 4 native binding-manifest fragment carried by `consensus_constants_native_binding_manifest_pre_rotation`."
       ],
-      "evidence_level": "machine_checked_behavioral"
+      "evidence_level": "machine_checked_universal"
     },
     {
       "section_key": "consensus_constants_native_binding_manifest_pre_rotation",


### PR DESCRIPTION
## Summary
- uplift `consensus_constants_witness_lengths_pre_rotation` from behavioral to universal
- rebase the row on `validateWitnessItemLengthsRegistry Rotation.PRE_ROTATION_REGISTRY` via the existing bridge theorem
- add registry-aware ML-DSA iff and exhaustive outcome theorems
- sync coverage counts in `PROOF_COVERAGE.md` and `RISK_MODEL.md`

## Verification
- `~/.elan/bin/lake build`
- `python3 tools/check_formal_registry_truth.py`
- `check_formal_disposition_for_section_hashes.py`
- `check_formal_coverage.py`
- `check_formal_refinement_bridge.py`
- `check_formal_claims_lint.py`
- `git diff --check`
- `bash tools/discipline-gate.sh --yes`
- `bash tools/self-audit-gate.sh --yes`
- sanctioned `cl push` local formal review (`summary-contract: PASS`)

## Scope
- no claim about arbitrary post-rotation registries
- no claim about parse-stage canonicalization in `TxParseV2.parseWitnessItemWithRegistry`

<!-- rubin-agent-meta actor=Codex action=pr-create via=cl branch=codex/consensus-constants-witness-uplift wt=rubin-formal utc=2026-04-12T20:53:49Z -->
